### PR TITLE
Pass references to CSG objects in favor of passing std::shared  for CSG objects

### DIFF
--- a/framework/doc/content/source/csg/CSGBase.md
+++ b/framework/doc/content/source/csg/CSGBase.md
@@ -63,7 +63,7 @@ The following sections explain in detail how to do this as a part of the `genera
 ### Surfaces
 
 Various methods exist to create `CSGSurface` objects (below).
-All surface creation methods will return a shared pointer to that generated surface (`std::shared_ptr<CSGSurface>`).
+All surface creation methods will return a const reference to that generated surface (`const & CSGSurface`).
 
 | Surface Type | Method | Description |
 |---------|--------|------------|
@@ -77,8 +77,8 @@ Options for boundary types are `TRANSMISSION` (default), `VACUUM`, and `REFLECTI
 
 The `CSGSurface` objects can then be accessed or updated with the following methods from `CSGBase`:
 
-- `getAllSurfaces`: retrieve a map of names to shared pointers for of all `CSGSurface` objects
-- `getSurfaceByName`: retrieve the shared pointer to the `CSGSurface` of the specified name
+- `getAllSurfaces`: retrieve a list of const references to all `CSGSurface` objects defined within the `CSGBase` object
+- `getSurfaceByName`: retrieve a const reference to the `CSGSurface` of the specified name
 - `renameSurface`: change the name of the `CSGSurface`
 - `updateSurfaceBoundaryType`: change the boundary type of the `CSGSurface` (`TRANSMISSION`, `VACUUM`, or `REFLECTIVE`)
 
@@ -91,30 +91,30 @@ auto p1 = Point(1, 2, 3);
 auto p2 = Point(1, 1, 0);
 auto p3 = Point(0, 0, 0);
 auto bc_refl = CSG::CSGSurface::BoundaryType::REFLECTIVE;
-auto plane = csg_object->createPlane('new_plane', p1, p2, p3, bc_refl);
+const auto & plane = csg_object->createPlane('new_plane', p1, p2, p3, bc_refl);
 ```
 
 ```cpp
 // create a plane at x=2 (a=1, b=c=0, d=2)
-auto xplane = csg_obj->createPlane('xplane', 1.0, 0.0, 0.0, 2.0);
+const auto & xplane = csg_obj->createPlane('xplane', 1.0, 0.0, 0.0, 2.0);
 ```
 
 ```cpp
 // create a sphere at the origin with radius 5
-auto sphere1 = csg_obj->createSphere('origin_sphere', 5.0);
+const auto & sphere1 = csg_obj->createSphere('origin_sphere', 5.0);
 ```
 
 ```cpp
 // create a sphere at the point (1, 2, 3) of radius 4
 auto center = Point(1, 2, 3);
-auto sphere2 = csg_obj->createSphere('new_sphere', center, 4.0);
+const auto & sphere2 = csg_obj->createSphere('new_sphere', center, 4.0);
 ```
 
 ```cpp
 // create x-, y-, and z- aligned cylinders of radius 5, each centered at (1, 2, 3)
-auto xcyl = csg_obj->createCylinder('xcylinder', 2, 3, 5, 'x');
-auto ycyl = csg_obj->createCylinder('ycylinder', 1, 3, 5, 'y');
-auto zcyl = csg_obj->createCylinder('zcylinder', 1, 2, 5, 'z');
+const auto & xcyl = csg_obj->createCylinder('xcylinder', 2, 3, 5, 'x');
+const auto & ycyl = csg_obj->createCylinder('ycylinder', 1, 3, 5, 'y');
+const auto & zcyl = csg_obj->createCylinder('zcylinder', 1, 2, 5, 'z');
 ```
 
 ### Regions
@@ -160,7 +160,7 @@ The complement of the previous combination then defines the final region `~((-cy
 ### Cells
 
 A cell is an object defined by a region and a fill.
-To create any `CSGCell`, use the method `createCell` from `CSGBase` which will return a shared pointer to the `CSGCell` object that is created (`std::shared_ptr<CSGCell>`).
+To create any `CSGCell`, use the method `createCell` from `CSGBase` which will return a const reference to the `CSGCell` object that is created (`const CSGCell &`).
 At the time of calling `createCell`, a unique cell name, the cell region (`CSGRegion`), and an indicator of the fill must be provided.
 The `CSGRegion` is defined by boolean combinations of `CSGSurfaces` as described below.
 Three types of cell fills are currently supported: void, material, and universe.
@@ -170,24 +170,30 @@ For a cell with a `CSGUniverse` fill, pass it a shared pointer to the `CSGUniver
 
 The `CSGCell` objects can then be accessed or updated with the following methods from `CSGBase`:
 
-- `getAllCells`: retrieve a map of names to shared pointers for of all `CSGCell` objects
-- `getCellByName`: retrieve the shared pointer to the `CSGCell` of the specified name
-- `renameCell`: change the name of the `CSGCell`
+- `getAllCells`: retrieve a list of const references to all `CSGCell` objects defined within the `CSGBase` object
+- `getCellByName`: retrieve a const reference to the `CSGCell` object of the specified name
+- `renameCell`: change the name of the `CSGCell` object
 - `updateCellRegion`: change the region of the cell; if used, all `CSGSurface` objects used to define the new `CSGRegion` must also be a part of the current `CSGBase`
 
 ### Universes
 
-A universe is a collection of cells and is created by calling `createUniverse` from `CSGBase` which will return a shared pointer to the `CSGUniverse` object (`std::shared_ptr<CSGUniverse>`).
+A universe is a collection of cells and is created by calling `createUniverse` from `CSGBase` which will return a const reference to the `CSGUniverse` object (`const CSGUniverse &`).
 A `CSGUniverse` can be initialized as an empty universe, or by passing a vector of shared pointers to `CSGCell` objects.
 Any `CSGUniverse` object can be renamed (including the [root universe](#root-universe)) with `renameUniverse`.
+
+The `CSGUniverse` objects can then be accessed or updated with the following methods from `CSGBase`:
+
+- `getAllUniverses`: retrieve a list of const references to all `CSGUniverse` objects defined within the `CSGBase` object
+- `getUniverseByName`: retrieve a const reference to the `CSGUniverse` of the specified name
+- `renameUniverse`: change the name of the `CSGUniverse`
 
 Example:
 
 ```cpp
 // create an empty universe which will get cells added to it later
-auto empty_universe = csg_obj->createUniverse("empty_universe");
-// create a universe that is initialized with an existing list of shared pointers to CSGCell objects
-auto new_universe = csg_obj->createUniverse("new_universe", list_of_cells);
+const auto & empty_universe = csg_obj->createUniverse("empty_universe");
+// create a universe that is initialized with an existing list of references to CSGCell objects
+const auto & new_universe = csg_obj->createUniverse("new_universe", list_of_cells);
 ```
 
 #### Root Universe
@@ -201,38 +207,38 @@ However, the name of the root universe can be updated, though it won't change th
 
 Methods available for managing the root universe:
 
-- `getRootUniverse`: returns a shared pointer to the root universe of the `CSGBase` instance
+- `getRootUniverse`: returns a const reference to the root universe of the `CSGBase` instance
 - `renameRootUniverse`: change the name of the root universe
 
 #### Adding or Removing Cells
 
 There are multiple ways in which cells can be added to a universe:
 
-1. At the time of universe creation, a list of pointers to `CSGCell` objects can be passed into `createUniverse` (as described [above](#universes)). Example:
+1. At the time of universe creation, a list of references to `CSGCell` objects can be passed into `createUniverse` (as described [above](#universes)). Example:
 
 ```cpp
-auto new_universe = csg_obj->createUniverse("new_universe", list_of_cells);
+const auto & new_universe = csg_obj->createUniverse("new_universe", list_of_cells);
 ```
 
-2. When a `CSGCell` is created with `createCell`, a `CSGUniverse` can be passed as the final argument to indicate that the cell will be created and added directly to that specified universe. In this case, the cell will *not* be added to the root universe. A cell that has a universe fill type cannot be added to the same universe that is being used for the fill. For example:
+2. When a `CSGCell` is created with `createCell`, a pointer to a `CSGUniverse` can be passed as the final argument to indicate that the cell will be created and added directly to that specified universe. In this case, the cell will *not* be added to the root universe. A cell that has a universe fill type cannot be added to the same universe that is being used for the fill. For example:
 
 ```cpp
 // create an empty universe
-auto new_universe = csg_obj->createUniverse("new_univ");
+const auto & new_universe = csg_obj->createUniverse("new_univ");
 // create a new void cell and add it directly to the new empty universe;
 // do not add to the root universe
-auto new_cell_in_univ = csg_obj->createCell("new_cell", region, new_universe);
+const auto & new_cell_in_univ = csg_obj->createCell("new_cell", region, &new_universe);
 ```
 
 3. A cell or list of cells can be added to an existing universe with the `addCellToUniverse` and `addCellsToUniverse` methods. In this case, if a `CSGCell` exists in another `CSGUniverse` (such as the root universe), it will *not* be removed when being added to another (i.e. if the same behavior as option 2 above is desired, the cell will have to be manually removed from the root universe). The following two examples will produce the same outcome:
 
 ```cpp
 // create a list of cells and add to an existing universe after creating all of them
-std::vector<std::shared_ptr<CSG::CSGCell>> list_of_cells;
+std::vector<std::reference_wrapper<const CSG::CSGCell>> list_of_cells;
 for (unsigned int i = 0; i < num_cells_to_add; ++i)
 {
     // creating new_cell here will add it to the root universe
-    auto new_cell = csg_obj->createCell("new_cell_" + std::to_string(i), regions[i]);
+    const auto & new_cell = csg_obj->createCell("new_cell_" + std::to_string(i), regions[i]);
     list_of_cells.push_back(new_cell);
 }
 // add to an existing universe; cells will still remain in the root universe
@@ -245,7 +251,7 @@ csg_obj->addCellsToUniverse(existing_universe, list_of_cells);
 for (unsigned int i = 0; i < num_cells_to_add; ++i)
 {
     // creating new_cell here will add it to the root universe
-    auto new_cell = csg_obj->createCell("new_cell_" + std::to_string(i), regions[i]);
+    const auto & new_cell = csg_obj->createCell("new_cell_" + std::to_string(i), regions[i]);
     csg_obj->addCellToUniverse(existing_universe, new_cell);
 }
 ```
@@ -255,11 +261,11 @@ An example use would be to take the previous two examples and remove the cells f
 
 ```cpp
 // create a list of cells and add to an existing universe after creating all of them
-std::vector<std::shared_ptr<CSG::CSGCell>> list_of_cells;
+std::vector<std::reference_wrapper<const CSG::CSGCell>> list_of_cells;
 for (unsigned int i = 0; i < num_cells_to_add; ++i)
 {
     // creating new_cell here will add it to the root universe
-    auto new_cell = csg_obj->createCell("new_cell_" + std::to_string(i), regions[i]);
+    const auto & new_cell = csg_obj->createCell("new_cell_" + std::to_string(i), regions[i]);
     list_of_cells.push_back(new_cell);
 }
 // add to an existing universe and explicitly remove them from root
@@ -272,7 +278,7 @@ csg_obj->removeCellsFromUniverse(csg_obj->getRootUniverse(), list_of_cells);
 for (unsigned int i = 0; i < num_cells_to_add; ++i)
 {
     // creating new_cell here will add it to the root universe
-    auto new_cell = csg_obj->createCell("new_cell_" + std::to_string(i), regions[i]);
+    const auto & new_cell = csg_obj->createCell("new_cell_" + std::to_string(i), regions[i]);
     csg_obj->addCellToUniverse(existing_universe, new_cell);
     csg_obj->removeCellFromUniverse(csg_obj->getRootUniverse(), new_cell);
 }
@@ -393,10 +399,11 @@ For example, if a cell were to be created, the current name and region could be 
 
 ```cpp
 // a cell is created using CSGBase
-auto cell = csg_obj->createCell("cell_name", region);
+const auto & cell = csg_obj->createCell("cell_name", region);
 // the current name and region of that cell can be retrieved directly from the CSGCell object
-auto name = cell->getName();
-auto region = cell->getRegion();
+const auto name = cell.getName();
+const auto & region = cell.getRegion();
+
 // changing the name and region requires using methods in CSGBase
 csg_obj->renameCell(cell, "new_name");
 csg_obj->updateCellRegion(cell, new_region);
@@ -469,14 +476,14 @@ ExamplePrismCSGMeshGenerator::generateCSG()
     // object name includes the mesh generator name for uniqueness
     const auto surf_name = mg_name + "_surf_" + surf_names[i];
     // create the plane for one face of the prism
-    auto plane_ptr = csg_obj->createPlaneFromPoints(
+    const auto & csg_plane = csg_obj->createPlaneFromPoints(
         surf_name, points_on_planes[i][0], points_on_planes[i][1], points_on_planes[i][2]);
     // determine where the plane is in relation to the centroid to be able to set the halfspace
-    const auto region_direction = plane_ptr->directionFromPoint(centroid);
+    const auto region_direction = csg_plane.directionFromPoint(centroid);
     // halfspace is either positive (+plane_ptr) or negative (-plane_ptr)
     / /depending on the direction to the centroid
     auto halfspace =
-        ((region_direction == CSG::CSGSurface::Direction::POSITIVE) ? +plane_ptr : -plane_ptr);
+        ((region_direction == CSG::CSGSurface::Direction::POSITIVE) ? +csg_plane : -csg_plane);
     // check if this is the first halfspace to be added to the region,
     // if not, update the existing region with the intersection of the regions (&=)
     if (region.getRegionType() == CSG::CSGRegion::RegionType::EMPTY)
@@ -524,9 +531,9 @@ ExampleAxialSurfaceMeshGenerator::generateCSG()
 
   // get the expected existing cell
   const auto cell_name = inp_name + "_square_cell";
-  auto cell_ptr = csg_obj->getCellByName(cell_name);
+  const auto & inp_cell = csg_obj->getCellByName(cell_name);
   // get the existing cell region to update
-  auto cell_region = cell_ptr->getRegion();
+  auto cell_region = inp_cell.getRegion();
 
   // centroid used to determine direction for halfspace
   const auto centroid = Point(0, 0, 0);
@@ -540,19 +547,19 @@ ExampleAxialSurfaceMeshGenerator::generateCSG()
     const auto surf_name = mg_name + "_surf_" + surf_names[i];
     // create the plane
     // z plane equation: 0.0*x + 0.0*y + 1.0*z = (+/-)0.5 * axial_height
-    auto plane_ptr = csg_obj->createPlaneFromCoefficients(surf_name, 0.0, 0.0, 1.0, coeffs[i]);
+    const auto & csg_plane = csg_obj->createPlaneFromCoefficients(surf_name, 0.0, 0.0, 1.0, coeffs[i]);
     // determine the halfspace to add as an updated intersection
-    const auto region_direction = plane_ptr->directionFromPoint(centroid);
+    const auto region_direction = csg_plane.directionFromPoint(centroid);
     auto halfspace =
-        ((region_direction == CSG::CSGSurface::Direction::POSITIVE) ? +plane_ptr : -plane_ptr);
+        ((region_direction == CSG::CSGSurface::Direction::POSITIVE) ? +csg_plane : -csg_plane);
     // update the existing region with a halfspace
     cell_region &= halfspace;
   }
 
   // set the new region for the existing cell
-  csg_obj->updateCellRegion(cell_ptr, cell_region);
+  csg_obj->updateCellRegion(inp_cell, cell_region);
 
-  // rename the root universe which currently contains just the cell defined by cell_ptr
+  // rename the root universe which currently contains just the cell defined by inp_cell
   csg_obj->renameRootUniverse(mg_name + "_finite_prism_univ");
 
   return csg_obj;

--- a/framework/include/csg/CSGBase.h
+++ b/framework/include/csg/CSGBase.h
@@ -49,13 +49,13 @@ public:
    * @param p3 point 3
    * @param boundary (optional) CSGSurface::BoundaryType boundary condition for the surface (default
    * TRANSMISSION)
-   * @return shared pointer to CSGSurface object
+   * @return reference to CSGSurface object
    */
-  std::shared_ptr<CSGSurface>
+  CSGSurface &
   createPlaneFromPoints(const std::string name,
-                        const Point p1,
-                        const Point p2,
-                        const Point p3,
+                        const Point & p1,
+                        const Point & p2,
+                        const Point & p3,
                         CSGSurface::BoundaryType boundary = CSGSurface::BoundaryType::TRANSMISSION)
   {
     return _surface_list.addPlaneFromPoints(name, p1, p2, p3, boundary);
@@ -71,9 +71,9 @@ public:
    * @param d coefficient d
    * @param boundary (optional) CSGSurface::BoundaryType boundary condition for the surface (default
    * TRANSMISSION)
-   * @return shared pointer to CSGSurface object
+   * @return reference to CSGSurface object
    */
-  std::shared_ptr<CSGSurface> createPlaneFromCoefficients(
+  CSGSurface & createPlaneFromCoefficients(
       const std::string name,
       const Real a,
       const Real b,
@@ -91,9 +91,9 @@ public:
    * @param r radius
    * @param boundary (optional) CSGSurface::BoundaryType boundary condition for the surface (default
    * TRANSMISSION)
-   * @return shared pointer to CSGSurface object
+   * @return reference to CSGSurface object
    */
-  std::shared_ptr<CSGSurface>
+  CSGSurface &
   createSphere(const std::string name,
                const Real r,
                CSGSurface::BoundaryType boundary = CSGSurface::BoundaryType::TRANSMISSION)
@@ -109,9 +109,9 @@ public:
    * @param r radius
    * @param boundary (optional) CSGSurface::BoundaryType boundary condition for the surface (default
    * TRANSMISSION)
-   * @return shared pointer to CSGSurface object
+   * @return reference to CSGSurface object
    */
-  std::shared_ptr<CSGSurface>
+  CSGSurface &
   createSphere(const std::string name,
                const Point center,
                const Real r,
@@ -133,9 +133,9 @@ public:
    * @param r radius
    * @param boundary (optional) CSGSurface::BoundaryType boundary condition for the surface (default
    * TRANSMISSION)
-   * @return shared pointer to CSGSurface object
+   * @return reference to CSGSurface object
    */
-  std::shared_ptr<CSGSurface>
+  CSGSurface &
   createCylinder(const std::string name,
                  const Real x0,
                  const Real x1,
@@ -149,23 +149,17 @@ public:
   /**
    * @brief Get all surface objects
    *
-   * @return map of names to CSGSurface objects
+   * @return list of pointers to all CSGSurface objects in CSGBase
    */
-  const std::map<std::string, std::shared_ptr<CSGSurface>> & getAllSurfaces() const
-  {
-    return _surface_list.getAllSurfaces();
-  }
+  std::vector<CSGSurface *> getAllSurfaces() const { return _surface_list.getAllSurfaces(); }
 
   /**
    * @brief Get a Surface object by name
    *
    * @param name surface name
-   * @return shared pointer to CSGSurface object
+   * @return reference to CSGSurface object
    */
-  const std::shared_ptr<CSGSurface> & getSurfaceByName(const std::string name)
-  {
-    return _surface_list.getSurface(name);
-  }
+  CSGSurface & getSurfaceByName(const std::string name) { return _surface_list.getSurface(name); }
 
   /**
    * @brief rename the specified surface
@@ -173,7 +167,7 @@ public:
    * @param surface CSGSurface to rename
    * @param name new name
    */
-  void renameSurface(const std::shared_ptr<CSGSurface> surface, const std::string name)
+  void renameSurface(CSGSurface & surface, const std::string name)
   {
     _surface_list.renameSurface(surface, name);
   }
@@ -184,10 +178,9 @@ public:
    * @param surface CSGSurface to update
    * @param boundary CSGSurface::BoundaryType to set
    */
-  void updateSurfaceBoundaryType(const std::shared_ptr<CSGSurface> surface,
-                                 CSGSurface::BoundaryType boundary)
+  void updateSurfaceBoundaryType(CSGSurface & surface, CSGSurface::BoundaryType boundary)
   {
-    surface->setBoundaryType(boundary);
+    surface.setBoundaryType(boundary);
   }
 
   /**

--- a/framework/include/csg/CSGBase.h
+++ b/framework/include/csg/CSGBase.h
@@ -192,12 +192,12 @@ public:
    * @param region cell region
    * @param add_to_univ (optional) universe to which this cell will be added (default is root
    * universe)
-   * @return std::shared_ptr<CSGCell> pointer to CSGCell that is created
+   * @return CSGCell & reference to CSGCell that is created
    */
-  std::shared_ptr<CSGCell> createCell(const std::string name,
-                                      const std::string mat_name,
-                                      const CSGRegion & region,
-                                      const std::shared_ptr<CSGUniverse> add_to_univ = nullptr);
+  CSGCell & createCell(const std::string name,
+                       const std::string mat_name,
+                       const CSGRegion & region,
+                       CSGUniverse * add_to_univ = nullptr);
 
   /**
    * @brief Create a Void Cell object
@@ -206,11 +206,10 @@ public:
    * @param region cell region
    * @param add_to_univ (optional) universe to which this cell will be added (default is root
    * universe)
-   * @return std::shared_ptr<CSGCell> pointer to CSGCell that is created
+   * @return CSGCell & reference to CSGCell that is created
    */
-  std::shared_ptr<CSGCell> createCell(const std::string name,
-                                      const CSGRegion & region,
-                                      const std::shared_ptr<CSGUniverse> add_to_univ = nullptr);
+  CSGCell &
+  createCell(const std::string name, const CSGRegion & region, CSGUniverse * add_to_univ = nullptr);
 
   /**
    * @brief Create a Universe Cell object
@@ -220,44 +219,35 @@ public:
    * @param region cell region
    * @param add_to_univ (optional) universe to which this cell will be added (default is root
    * universe)
-   * @return std::shared_ptr<CSGCell> pointer to cell that is created
+   * @return CSGCell & reference to cell that is created
    */
-  std::shared_ptr<CSGCell> createCell(const std::string name,
-                                      const std::shared_ptr<CSGUniverse> fill_univ,
-                                      const CSGRegion & region,
-                                      const std::shared_ptr<CSGUniverse> add_to_univ = nullptr);
+  CSGCell & createCell(const std::string name,
+                       CSGUniverse & fill_univ,
+                       const CSGRegion & region,
+                       CSGUniverse * add_to_univ = nullptr);
 
   /**
    * @brief Get all cell objects
    *
-   * @return map of all names to CSGCell objects in this CSGBase instance
+   * @return list of pointers to all CSGCell objects in CSGBase
    */
-  const std::map<std::string, std::shared_ptr<CSGCell>> & getAllCells() const
-  {
-    return _cell_list.getAllCells();
-  }
+  std::vector<CSGCell *> getAllCells() const { return _cell_list.getAllCells(); }
 
   /**
    * @brief Get a Cell object by name
    *
    * @param name cell name
-   * @return shared pointer to CSGCell object
+   * @return reference to CSGCell object
    */
-  const std::shared_ptr<CSGCell> & getCellByName(const std::string name)
-  {
-    return _cell_list.getCell(name);
-  }
+  CSGCell & getCellByName(const std::string name) { return _cell_list.getCell(name); }
 
   /**
    * @brief rename the specified cell
    *
-   * @param cell pointer to CSGCell to rename
+   * @param cell reference to CSGCell to rename
    * @param name new name
    */
-  void renameCell(const std::shared_ptr<CSGCell> cell, const std::string name)
-  {
-    _cell_list.renameCell(cell, name);
-  }
+  void renameCell(CSGCell & cell, const std::string name) { _cell_list.renameCell(cell, name); }
 
   /**
    * @brief change the region of the specified cell
@@ -265,14 +255,14 @@ public:
    * @param cell cell to update the region for
    * @param region new region to assign to cell
    */
-  void updateCellRegion(const std::shared_ptr<CSGCell> cell, const CSGRegion & region);
+  void updateCellRegion(CSGCell & cell, const CSGRegion & region);
 
   /**
    * @brief Get the Root Universe object
    *
-   * @return  shared pointer to CSGUniverse
+   * @return reference to root CSGUniverse
    */
-  std::shared_ptr<CSGUniverse> getRootUniverse() const { return _universe_list.getRoot(); }
+  CSGUniverse & getRootUniverse() { return _universe_list.getRoot(); }
 
   /**
    * @brief rename the root universe for this instance (default is ROOT_UNIVERSE)
@@ -287,10 +277,10 @@ public:
   /**
    * @brief rename the specified universe
    *
-   * @param universe pointer to CSGUniverse to rename
+   * @param universe reference to CSGUniverse to rename
    * @param name new name
    */
-  void renameUniverse(const std::shared_ptr<CSGUniverse> universe, const std::string name)
+  void renameUniverse(CSGUniverse & universe, const std::string name)
   {
     _universe_list.renameUniverse(universe, name);
   }
@@ -299,22 +289,18 @@ public:
    * @brief Create an empty Universe object
    *
    * @param name unique universe name
-   * @return std::shared_ptr<CSGUniverse> pointer CSGUniverse that is created
+   * @return CSGUniverse & reference to CSGUniverse that is created
    */
-  std::shared_ptr<CSGUniverse> createUniverse(const std::string name)
-  {
-    return _universe_list.addUniverse(name);
-  }
+  CSGUniverse & createUniverse(const std::string name) { return _universe_list.addUniverse(name); }
 
   /**
    * @brief Create a Universe object from list of cells
    *
    * @param name unique universe name
    * @param cells list of cells to add to universe
-   * @return std::shared_ptr<CSGUniverse> pointer CSGUniverse that is created
+   * @return CSGUniverse & reference to CSGUniverse that is created
    */
-  std::shared_ptr<CSGUniverse> createUniverse(const std::string name,
-                                              std::vector<std::shared_ptr<CSGCell>> cells);
+  CSGUniverse & createUniverse(const std::string name, std::vector<CSGCell *> cells);
 
   /**
    * @brief Add a cell to an existing universe
@@ -322,17 +308,15 @@ public:
    * @param universe universe to which to add the cell
    * @param cell cell to add
    */
-  void addCellToUniverse(const std::shared_ptr<CSGUniverse> universe,
-                         std::shared_ptr<CSGCell> cell);
+  void addCellToUniverse(CSGUniverse & universe, CSGCell & cell);
 
   /**
    * @brief Add a list of cells to an existing universe
    *
    * @param universe universe to which to add the cells
-   * @param cells list of cells to add
+   * @param cells list of pointers to cells to add
    */
-  void addCellsToUniverse(const std::shared_ptr<CSGUniverse> universe,
-                          std::vector<std::shared_ptr<CSGCell>> cells);
+  void addCellsToUniverse(CSGUniverse & universe, std::vector<CSGCell *> cells);
 
   /**
    * @brief Remove a cell from an existing universe
@@ -340,35 +324,30 @@ public:
    * @param universe universe from which to remove the cell
    * @param cell cell to remove
    */
-  void removeCellFromUniverse(const std::shared_ptr<CSGUniverse> universe,
-                              std::shared_ptr<CSGCell> cell);
+  void removeCellFromUniverse(CSGUniverse & universe, CSGCell & cell);
 
   /**
    * @brief Remove a list of cells from an existing universe
    *
    * @param universe universe from which to remove the cells
-   * @param cells list of cells to remove
+   * @param cells list of pointers to cells to remove
    */
-  void removeCellsFromUniverse(const std::shared_ptr<CSGUniverse> universe,
-                               std::vector<std::shared_ptr<CSGCell>> cells);
+  void removeCellsFromUniverse(CSGUniverse & universe, std::vector<CSGCell *> cells);
 
   /**
    * @brief Get all universe objects
    *
-   * @return map of all names to CSGUniverse objects in this CSGBase instance
+   * @return list of pointers to CSGUniverse objects in this CSGBase instance
    */
-  const std::map<std::string, std::shared_ptr<CSGUniverse>> & getAllUniverses() const
-  {
-    return _universe_list.getAllUniverses();
-  }
+  std::vector<CSGUniverse *> getAllUniverses() { return _universe_list.getAllUniverses(); }
 
   /**
    * @brief Get a universe object by name
    *
    * @param name universe name
-   * @return shared pointer to CSGUniverse object
+   * @return reference to CSGUniverse object
    */
-  const std::shared_ptr<CSGUniverse> & getUniverseByName(const std::string name)
+  CSGUniverse & getUniverseByName(const std::string name)
   {
     return _universe_list.getUniverse(name);
   }
@@ -429,19 +408,19 @@ public:
    * @brief generate the JSON representation output for the CSG object
    *
    */
-  nlohmann::json generateOutput() const;
+  nlohmann::json generateOutput();
 
 private:
   /// Check universes linked to root universe match universes defined in _universe_list
-  void checkUniverseLinking() const;
+  void checkUniverseLinking();
 
   /**
    * @brief Recursive method to retrieve all universes linked to current universe
    *
-   * @param univ Pointer to universe under consideration
+   * @param univ Reference to universe under consideration
    * @param linked_universe_name List of universe names linked to current universe
    */
-  void getLinkedUniverses(const std::shared_ptr<CSGUniverse> & univ,
+  void getLinkedUniverses(const CSGUniverse & univ,
                           std::vector<std::string> & linked_universe_names) const;
 
   /**
@@ -517,7 +496,7 @@ private:
   void checkRegionSurfaces(const CSGRegion & region);
 
   // check that cell being accessed is a part of this CSGBase instance
-  bool checkCellInBase(std::shared_ptr<CSGCell> cell);
+  bool checkCellInBase(CSGCell & cell);
 
   /// List of surfaces associated with CSG object
   CSGSurfaceList _surface_list;

--- a/framework/include/csg/CSGBase.h
+++ b/framework/include/csg/CSGBase.h
@@ -149,9 +149,12 @@ public:
   /**
    * @brief Get all surface objects
    *
-   * @return list of pointers to all CSGSurface objects in CSGBase
+   * @return list of references to all CSGSurface objects in CSGBase
    */
-  std::vector<CSGSurface *> getAllSurfaces() const { return _surface_list.getAllSurfaces(); }
+  std::vector<std::reference_wrapper<const CSGSurface>> getAllSurfaces() const
+  {
+    return _surface_list.getAllSurfaces();
+  }
 
   /**
    * @brief Get a Surface object by name
@@ -230,9 +233,12 @@ public:
   /**
    * @brief Get all cell objects
    *
-   * @return list of pointers to all CSGCell objects in CSGBase
+   * @return list of references to all CSGCell objects in CSGBase
    */
-  std::vector<CSGCell *> getAllCells() const { return _cell_list.getAllCells(); }
+  std::vector<std::reference_wrapper<const CSGCell>> getAllCells() const
+  {
+    return _cell_list.getAllCells();
+  }
 
   /**
    * @brief Get a Cell object by name
@@ -307,7 +313,8 @@ public:
    * @param cells list of cells to add to universe
    * @return CSGUniverse & reference to CSGUniverse that is created
    */
-  const CSGUniverse & createUniverse(const std::string name, std::vector<const CSGCell *> cells);
+  const CSGUniverse & createUniverse(const std::string name,
+                                     std::vector<std::reference_wrapper<const CSGCell>> & cells);
 
   /**
    * @brief Add a cell to an existing universe
@@ -321,9 +328,10 @@ public:
    * @brief Add a list of cells to an existing universe
    *
    * @param universe universe to which to add the cells
-   * @param cells list of pointers to cells to add
+   * @param cells list of references to cells to add
    */
-  void addCellsToUniverse(const CSGUniverse & universe, std::vector<const CSGCell *> cells);
+  void addCellsToUniverse(const CSGUniverse & universe,
+                          std::vector<std::reference_wrapper<const CSGCell>> & cells);
 
   /**
    * @brief Remove a cell from an existing universe
@@ -337,16 +345,20 @@ public:
    * @brief Remove a list of cells from an existing universe
    *
    * @param universe universe from which to remove the cells
-   * @param cells list of pointers to cells to remove
+   * @param cells list of references to cells to remove
    */
-  void removeCellsFromUniverse(const CSGUniverse & universe, std::vector<const CSGCell *> cells);
+  void removeCellsFromUniverse(const CSGUniverse & universe,
+                               std::vector<std::reference_wrapper<const CSGCell>> & cells);
 
   /**
    * @brief Get all universe objects
    *
-   * @return list of pointers to CSGUniverse objects in this CSGBase instance
+   * @return list of references to CSGUniverse objects in this CSGBase instance
    */
-  std::vector<CSGUniverse *> getAllUniverses() const { return _universe_list.getAllUniverses(); }
+  std::vector<std::reference_wrapper<const CSGUniverse>> getAllUniverses() const
+  {
+    return _universe_list.getAllUniverses();
+  }
 
   /**
    * @brief Get a universe object by name

--- a/framework/include/csg/CSGBase.h
+++ b/framework/include/csg/CSGBase.h
@@ -51,7 +51,7 @@ public:
    * TRANSMISSION)
    * @return reference to CSGSurface object
    */
-  CSGSurface &
+  const CSGSurface &
   createPlaneFromPoints(const std::string name,
                         const Point & p1,
                         const Point & p2,
@@ -73,7 +73,7 @@ public:
    * TRANSMISSION)
    * @return reference to CSGSurface object
    */
-  CSGSurface & createPlaneFromCoefficients(
+  const CSGSurface & createPlaneFromCoefficients(
       const std::string name,
       const Real a,
       const Real b,
@@ -93,7 +93,7 @@ public:
    * TRANSMISSION)
    * @return reference to CSGSurface object
    */
-  CSGSurface &
+  const CSGSurface &
   createSphere(const std::string name,
                const Real r,
                CSGSurface::BoundaryType boundary = CSGSurface::BoundaryType::TRANSMISSION)
@@ -111,7 +111,7 @@ public:
    * TRANSMISSION)
    * @return reference to CSGSurface object
    */
-  CSGSurface &
+  const CSGSurface &
   createSphere(const std::string name,
                const Point center,
                const Real r,
@@ -135,7 +135,7 @@ public:
    * TRANSMISSION)
    * @return reference to CSGSurface object
    */
-  CSGSurface &
+  const CSGSurface &
   createCylinder(const std::string name,
                  const Real x0,
                  const Real x1,
@@ -159,7 +159,10 @@ public:
    * @param name surface name
    * @return reference to CSGSurface object
    */
-  CSGSurface & getSurfaceByName(const std::string name) { return _surface_list.getSurface(name); }
+  const CSGSurface & getSurfaceByName(const std::string name) const
+  {
+    return _surface_list.getSurface(name);
+  }
 
   /**
    * @brief rename the specified surface
@@ -167,7 +170,7 @@ public:
    * @param surface CSGSurface to rename
    * @param name new name
    */
-  void renameSurface(CSGSurface & surface, const std::string name)
+  void renameSurface(const CSGSurface & surface, const std::string name)
   {
     _surface_list.renameSurface(surface, name);
   }
@@ -178,10 +181,7 @@ public:
    * @param surface CSGSurface to update
    * @param boundary CSGSurface::BoundaryType to set
    */
-  void updateSurfaceBoundaryType(CSGSurface & surface, CSGSurface::BoundaryType boundary)
-  {
-    surface.setBoundaryType(boundary);
-  }
+  void updateSurfaceBoundaryType(const CSGSurface & surface, CSGSurface::BoundaryType boundary);
 
   /**
    * @brief Create a Material Cell object
@@ -192,12 +192,12 @@ public:
    * @param region cell region
    * @param add_to_univ (optional) universe to which this cell will be added (default is root
    * universe)
-   * @return CSGCell & reference to CSGCell that is created
+   * @return const CSGCell & reference to CSGCell that is created
    */
-  CSGCell & createCell(const std::string name,
-                       const std::string mat_name,
-                       const CSGRegion & region,
-                       CSGUniverse * add_to_univ = nullptr);
+  const CSGCell & createCell(const std::string name,
+                             const std::string mat_name,
+                             const CSGRegion & region,
+                             const CSGUniverse * add_to_univ = nullptr);
 
   /**
    * @brief Create a Void Cell object
@@ -206,10 +206,11 @@ public:
    * @param region cell region
    * @param add_to_univ (optional) universe to which this cell will be added (default is root
    * universe)
-   * @return CSGCell & reference to CSGCell that is created
+   * @return const CSGCell & reference to CSGCell that is created
    */
-  CSGCell &
-  createCell(const std::string name, const CSGRegion & region, CSGUniverse * add_to_univ = nullptr);
+  const CSGCell & createCell(const std::string name,
+                             const CSGRegion & region,
+                             const CSGUniverse * add_to_univ = nullptr);
 
   /**
    * @brief Create a Universe Cell object
@@ -219,12 +220,12 @@ public:
    * @param region cell region
    * @param add_to_univ (optional) universe to which this cell will be added (default is root
    * universe)
-   * @return CSGCell & reference to cell that is created
+   * @return const CSGCell & reference to cell that is created
    */
-  CSGCell & createCell(const std::string name,
-                       CSGUniverse & fill_univ,
-                       const CSGRegion & region,
-                       CSGUniverse * add_to_univ = nullptr);
+  const CSGCell & createCell(const std::string name,
+                             const CSGUniverse & fill_univ,
+                             const CSGRegion & region,
+                             const CSGUniverse * add_to_univ = nullptr);
 
   /**
    * @brief Get all cell objects
@@ -239,7 +240,7 @@ public:
    * @param name cell name
    * @return reference to CSGCell object
    */
-  CSGCell & getCellByName(const std::string name) { return _cell_list.getCell(name); }
+  const CSGCell & getCellByName(const std::string name) const { return _cell_list.getCell(name); }
 
   /**
    * @brief rename the specified cell
@@ -247,7 +248,10 @@ public:
    * @param cell reference to CSGCell to rename
    * @param name new name
    */
-  void renameCell(CSGCell & cell, const std::string name) { _cell_list.renameCell(cell, name); }
+  void renameCell(const CSGCell & cell, const std::string name)
+  {
+    _cell_list.renameCell(cell, name);
+  }
 
   /**
    * @brief change the region of the specified cell
@@ -255,14 +259,14 @@ public:
    * @param cell cell to update the region for
    * @param region new region to assign to cell
    */
-  void updateCellRegion(CSGCell & cell, const CSGRegion & region);
+  void updateCellRegion(const CSGCell & cell, const CSGRegion & region);
 
   /**
    * @brief Get the Root Universe object
    *
    * @return reference to root CSGUniverse
    */
-  CSGUniverse & getRootUniverse() { return _universe_list.getRoot(); }
+  const CSGUniverse & getRootUniverse() const { return _universe_list.getRoot(); }
 
   /**
    * @brief rename the root universe for this instance (default is ROOT_UNIVERSE)
@@ -280,7 +284,7 @@ public:
    * @param universe reference to CSGUniverse to rename
    * @param name new name
    */
-  void renameUniverse(CSGUniverse & universe, const std::string name)
+  void renameUniverse(const CSGUniverse & universe, const std::string name)
   {
     _universe_list.renameUniverse(universe, name);
   }
@@ -291,7 +295,10 @@ public:
    * @param name unique universe name
    * @return CSGUniverse & reference to CSGUniverse that is created
    */
-  CSGUniverse & createUniverse(const std::string name) { return _universe_list.addUniverse(name); }
+  const CSGUniverse & createUniverse(const std::string name)
+  {
+    return _universe_list.addUniverse(name);
+  }
 
   /**
    * @brief Create a Universe object from list of cells
@@ -300,7 +307,7 @@ public:
    * @param cells list of cells to add to universe
    * @return CSGUniverse & reference to CSGUniverse that is created
    */
-  CSGUniverse & createUniverse(const std::string name, std::vector<CSGCell *> cells);
+  const CSGUniverse & createUniverse(const std::string name, std::vector<const CSGCell *> cells);
 
   /**
    * @brief Add a cell to an existing universe
@@ -308,7 +315,7 @@ public:
    * @param universe universe to which to add the cell
    * @param cell cell to add
    */
-  void addCellToUniverse(CSGUniverse & universe, CSGCell & cell);
+  void addCellToUniverse(const CSGUniverse & universe, const CSGCell & cell);
 
   /**
    * @brief Add a list of cells to an existing universe
@@ -316,7 +323,7 @@ public:
    * @param universe universe to which to add the cells
    * @param cells list of pointers to cells to add
    */
-  void addCellsToUniverse(CSGUniverse & universe, std::vector<CSGCell *> cells);
+  void addCellsToUniverse(const CSGUniverse & universe, std::vector<const CSGCell *> cells);
 
   /**
    * @brief Remove a cell from an existing universe
@@ -324,7 +331,7 @@ public:
    * @param universe universe from which to remove the cell
    * @param cell cell to remove
    */
-  void removeCellFromUniverse(CSGUniverse & universe, CSGCell & cell);
+  void removeCellFromUniverse(const CSGUniverse & universe, const CSGCell & cell);
 
   /**
    * @brief Remove a list of cells from an existing universe
@@ -332,14 +339,14 @@ public:
    * @param universe universe from which to remove the cells
    * @param cells list of pointers to cells to remove
    */
-  void removeCellsFromUniverse(CSGUniverse & universe, std::vector<CSGCell *> cells);
+  void removeCellsFromUniverse(const CSGUniverse & universe, std::vector<const CSGCell *> cells);
 
   /**
    * @brief Get all universe objects
    *
    * @return list of pointers to CSGUniverse objects in this CSGBase instance
    */
-  std::vector<CSGUniverse *> getAllUniverses() { return _universe_list.getAllUniverses(); }
+  std::vector<CSGUniverse *> getAllUniverses() const { return _universe_list.getAllUniverses(); }
 
   /**
    * @brief Get a universe object by name
@@ -347,7 +354,7 @@ public:
    * @param name universe name
    * @return reference to CSGUniverse object
    */
-  CSGUniverse & getUniverseByName(const std::string name)
+  const CSGUniverse & getUniverseByName(const std::string name)
   {
     return _universe_list.getUniverse(name);
   }
@@ -408,11 +415,22 @@ public:
    * @brief generate the JSON representation output for the CSG object
    *
    */
-  nlohmann::json generateOutput();
+  nlohmann::json generateOutput() const;
 
 private:
+  /**
+   * @brief Get a Surface object by name.
+   *
+   * Note:  This is a private method that returns a non-const reference. For the public method that
+   * returns a const reference, use `getSurfaceByName`
+   *
+   * @param name surface name
+   * @return reference to CSGSurface object
+   */
+  CSGSurface & getSurface(const std::string name) { return _surface_list.getSurface(name); }
+
   /// Check universes linked to root universe match universes defined in _universe_list
-  void checkUniverseLinking();
+  void checkUniverseLinking() const;
 
   /**
    * @brief Recursive method to retrieve all universes linked to current universe
@@ -493,10 +511,10 @@ private:
                         std::string new_root_name_incoming);
 
   // check that surfaces used in this region are a part of this CSGBase instance
-  void checkRegionSurfaces(const CSGRegion & region);
+  void checkRegionSurfaces(const CSGRegion & region) const;
 
   // check that cell being accessed is a part of this CSGBase instance
-  bool checkCellInBase(CSGCell & cell);
+  bool checkCellInBase(const CSGCell & cell) const;
 
   /// List of surfaces associated with CSG object
   CSGSurfaceList _surface_list;

--- a/framework/include/csg/CSGCell.h
+++ b/framework/include/csg/CSGCell.h
@@ -57,9 +57,7 @@ public:
    * @param univ universe to be the fill
    * @param region cell region
    */
-  CSGCell(const std::string name,
-          const std::shared_ptr<CSGUniverse> univ,
-          const CSGRegion & region);
+  CSGCell(const std::string name, CSGUniverse * univ, const CSGRegion & region);
 
   /**
    * Destructor
@@ -83,9 +81,9 @@ public:
   /**
    * @brief Get the cell fill if FillType is UNIVERSE
    *
-   * @return CSGUniverse pointer
+   * @return Reference to CSGUniverse fill
    */
-  const std::shared_ptr<CSGUniverse> & getFillUniverse() const;
+  const CSGUniverse & getFillUniverse() const;
 
   /**
    * @brief Get the cell fill material name if FillType is MATERIAL
@@ -123,6 +121,12 @@ public:
    */
   std::string getRegionAsString() const { return _region.toString(); }
 
+  /// Operator overload for checking if two CSGCell objects are equal
+  bool operator==(const CSGCell & other) const;
+
+  /// Operator overload for checking if two CSGCell objects are not equal
+  bool operator!=(const CSGCell & other) const;
+
 protected:
   // set the name of the cell - intentionally not public because
   // name needs to be managed at the CSGCellList level
@@ -145,7 +149,7 @@ protected:
   CSGRegion _region;
 
   /// Fill object if fill is CSGUniverse
-  const std::shared_ptr<CSGUniverse> _fill_universe;
+  CSGUniverse * _fill_universe;
 
   friend class CSGCellList; // needed for setName() access
   friend class CSGBase;     // needed for updateRegion() access

--- a/framework/include/csg/CSGCell.h
+++ b/framework/include/csg/CSGCell.h
@@ -57,7 +57,7 @@ public:
    * @param univ universe to be the fill
    * @param region cell region
    */
-  CSGCell(const std::string name, CSGUniverse * univ, const CSGRegion & region);
+  CSGCell(const std::string name, const CSGUniverse * univ, const CSGRegion & region);
 
   /**
    * Destructor
@@ -149,7 +149,7 @@ protected:
   CSGRegion _region;
 
   /// Fill object if fill is CSGUniverse
-  CSGUniverse * _fill_universe;
+  const CSGUniverse * _fill_universe;
 
   friend class CSGCellList; // needed for setName() access
   friend class CSGBase;     // needed for updateRegion() access

--- a/framework/include/csg/CSGCellList.h
+++ b/framework/include/csg/CSGCellList.h
@@ -73,11 +73,12 @@ protected:
   std::map<std::string, std::unique_ptr<CSGCell>> & getCellListMap() { return _cells; }
 
   /**
-   * @brief Get the all cells in CSGBase instance
+   * @brief Get all the cells in CSGBase instance
    *
-   * @return std::vector<CSGCell *> list of pointers to all CSGCell objects
+   * @return std::vector<std::reference_wrapper<const CSGCell>> list of references to all CSGCell
+   * objects
    */
-  std::vector<CSGCell *> getAllCells() const;
+  std::vector<std::reference_wrapper<const CSGCell>> getAllCells() const;
 
   /**
    * @brief Get the CSGCell by name

--- a/framework/include/csg/CSGCellList.h
+++ b/framework/include/csg/CSGCellList.h
@@ -37,10 +37,10 @@ protected:
    * @param mat_name material name (TODO: this will eventually be a material object and not just a
    * name)
    * @param region cell region
-   * @return std::shared_ptr<CSGCell> pointer to CSGCell with material fill that was created and
+   * @return CSGCell & reference to CSGCell with material fill that was created and
    * added to this CSGCellList
    */
-  std::shared_ptr<CSGCell> &
+  CSGCell &
   addMaterialCell(const std::string name, const std::string mat_name, const CSGRegion & region);
 
   /**
@@ -48,10 +48,10 @@ protected:
    *
    * @param name unique cell name
    * @param region cell region
-   * @return std::shared_ptr<CSGCell>pointer to CSGCell with void fill that was created and
+   * @return CSGCell & reference to CSGCell with void fill that was created and
    * added to this CSGCellList
    */
-  std::shared_ptr<CSGCell> & addVoidCell(const std::string name, const CSGRegion & region);
+  CSGCell & addVoidCell(const std::string name, const CSGRegion & region);
 
   /**
    * @brief Add a Universe Cell object to cell list
@@ -59,42 +59,47 @@ protected:
    * @param name unique cell name
    * @param univ universe
    * @param region cell region
-   * @return std::shared_ptr<CSGCell> pointer to CSGCell with universe fill that was created and
+   * @return CSGCell & reference to CSGCell with universe fill that was created and
    * added to this CSGCellList
    */
-  std::shared_ptr<CSGCell> & addUniverseCell(const std::string name,
-                                             const std::shared_ptr<CSGUniverse> univ,
-                                             const CSGRegion & region);
+  CSGCell & addUniverseCell(const std::string name, CSGUniverse & univ, const CSGRegion & region);
+
+  /**
+   * @brief Get map of all names to cells in cell list
+   *
+   * @return std::map<std::string, std::shared_ptr<CSGCell>>& map of all names to cells
+   */
+  std::map<std::string, std::shared_ptr<CSGCell>> & getCellListMap() { return _cells; }
 
   /**
    * @brief Get the all cells in CSGBase instance
    *
-   * @return const std::map<std::string, std::shared_ptr<CSGCell>>& map of all cells to CSGCell
-   * objects
+   * @return std::vector<CSGCell *> list of pointers to all CSGCell objects
    */
-  const std::map<std::string, std::shared_ptr<CSGCell>> & getAllCells() const { return _cells; }
+  std::vector<CSGCell *> getAllCells() const;
 
   /**
    * @brief Get the CSGCell by name
    *
    * @param name
-   * @return const std::shared_ptr<CSGCell>& pointer CSGCell of the specified name
+   * @return CSGCell & reference to CSGCell of the specified name
    */
-  const std::shared_ptr<CSGCell> & getCell(const std::string name) const;
+  CSGCell & getCell(const std::string name) const;
 
   /**
    * @brief add a cell to the CellList
    *
-   * @param cell cell to add to the CellList
+   * @param cell cell to add to the CellList.
    */
-  void addCell(const std::shared_ptr<CSGCell> & cell);
+  void addCell(std::shared_ptr<CSGCell> & cell);
 
   /**
    * @brief rename the specified cell
    *
+   * @param cell reference to CSGCell object that should be renamed
    * @param name new name
    */
-  void renameCell(const std::shared_ptr<CSGCell> & cell, const std::string name);
+  void renameCell(CSGCell & cell, const std::string name);
 
   /// Checks whether cell name already exists within CSGCellList object
   void checkCellName(const std::string name) const;

--- a/framework/include/csg/CSGCellList.h
+++ b/framework/include/csg/CSGCellList.h
@@ -67,9 +67,9 @@ protected:
   /**
    * @brief Get map of all names to cells in cell list
    *
-   * @return std::map<std::string, std::shared_ptr<CSGCell>>& map of all names to cells
+   * @return std::map<std::string, std::unique_ptr<CSGCell>>& map of all names to cells
    */
-  std::map<std::string, std::shared_ptr<CSGCell>> & getCellListMap() { return _cells; }
+  std::map<std::string, std::unique_ptr<CSGCell>> & getCellListMap() { return _cells; }
 
   /**
    * @brief Get the all cells in CSGBase instance
@@ -87,11 +87,12 @@ protected:
   CSGCell & getCell(const std::string name) const;
 
   /**
-   * @brief add a cell to the CellList
+   * @brief add a cell to the CellList. Ownership of cell will be trasnferred to cell list object
+   * that calls this function
    *
    * @param cell cell to add to the CellList.
    */
-  void addCell(std::shared_ptr<CSGCell> & cell);
+  void addCell(std::unique_ptr<CSGCell> & cell);
 
   /**
    * @brief rename the specified cell
@@ -105,7 +106,7 @@ protected:
   void checkCellName(const std::string name) const;
 
   /// Mapping of cell names to pointers of stored cell objects
-  std::map<std::string, std::shared_ptr<CSGCell>> _cells;
+  std::map<std::string, std::unique_ptr<CSGCell>> _cells;
 
   // Only CSGBase should be calling the methods in CSGCellList
   friend class CSGBase;

--- a/framework/include/csg/CSGCellList.h
+++ b/framework/include/csg/CSGCellList.h
@@ -62,7 +62,8 @@ protected:
    * @return CSGCell & reference to CSGCell with universe fill that was created and
    * added to this CSGCellList
    */
-  CSGCell & addUniverseCell(const std::string name, CSGUniverse & univ, const CSGRegion & region);
+  CSGCell &
+  addUniverseCell(const std::string name, const CSGUniverse & univ, const CSGRegion & region);
 
   /**
    * @brief Get map of all names to cells in cell list
@@ -100,7 +101,7 @@ protected:
    * @param cell reference to CSGCell object that should be renamed
    * @param name new name
    */
-  void renameCell(CSGCell & cell, const std::string name);
+  void renameCell(const CSGCell & cell, const std::string name);
 
   /// Checks whether cell name already exists within CSGCellList object
   void checkCellName(const std::string name) const;

--- a/framework/include/csg/CSGRegion.h
+++ b/framework/include/csg/CSGRegion.h
@@ -85,7 +85,10 @@ public:
    *
    * @return std::vector<CSGSurface *> list of pointers to surfaces that define the region
    */
-  std::vector<const CSGSurface *> getSurfaces() const { return _surfaces; };
+  const std::vector<std::reference_wrapper<const CSGSurface>> & getSurfaces() const
+  {
+    return _surfaces;
+  }
 
   /// Operator overload for &= add an intersection to the current region
   CSGRegion & operator&=(const CSGRegion & other_region);
@@ -107,11 +110,11 @@ protected:
   RegionType _region_type;
 
   /// Surface list associated with the region
-  std::vector<const CSGSurface *> _surfaces;
+  std::vector<std::reference_wrapper<const CSGSurface>> _surfaces;
 };
 
 /**
- * @brief strip the leading and trailing parentheses fromt the string
+ * @brief strip the leading and trailing parentheses from the string
  * if only the specified operator is present in the string
  *
  * @param region_str region string representation to simplify

--- a/framework/include/csg/CSGRegion.h
+++ b/framework/include/csg/CSGRegion.h
@@ -40,7 +40,7 @@ public:
   /**
    * Constructor for halfspace
    */
-  CSGRegion(CSGSurface & surf, const CSGSurface::Direction direction);
+  CSGRegion(const CSGSurface & surf, const CSGSurface::Direction direction);
 
   /**
    * Constructor for union and intersection
@@ -85,7 +85,7 @@ public:
    *
    * @return std::vector<CSGSurface *> list of pointers to surfaces that define the region
    */
-  std::vector<CSGSurface *> getSurfaces() const { return _surfaces; };
+  std::vector<const CSGSurface *> getSurfaces() const { return _surfaces; };
 
   /// Operator overload for &= add an intersection to the current region
   CSGRegion & operator&=(const CSGRegion & other_region);
@@ -107,7 +107,7 @@ protected:
   RegionType _region_type;
 
   /// Surface list associated with the region
-  std::vector<CSGSurface *> _surfaces;
+  std::vector<const CSGSurface *> _surfaces;
 };
 
 /**
@@ -123,10 +123,10 @@ std::string stripRegionString(std::string region_str, std::string op);
 /// Operation overloads for operation based region construction
 
 // positive halfspace (+)
-const CSGRegion operator+(CSGSurface & surf);
+const CSGRegion operator+(const CSGSurface & surf);
 
 // negative halfspace (-)
-const CSGRegion operator-(CSGSurface & surf);
+const CSGRegion operator-(const CSGSurface & surf);
 
 // intersection (&)
 const CSGRegion operator&(const CSGRegion & region_a, const CSGRegion & region_b);

--- a/framework/include/csg/CSGRegion.h
+++ b/framework/include/csg/CSGRegion.h
@@ -93,6 +93,12 @@ public:
   /// Operator overload for |= add a union to the current region
   CSGRegion & operator|=(const CSGRegion & other_region);
 
+  /// Operator overload for checking if two CSGRegion objects are equal
+  bool operator==(const CSGRegion & other) const;
+
+  /// Operator overload for checking if two CSGRegion objects are not equal
+  bool operator!=(const CSGRegion & other) const;
+
 protected:
   /// String representation of region - defaults to empty string
   std::string _region_str;

--- a/framework/include/csg/CSGRegion.h
+++ b/framework/include/csg/CSGRegion.h
@@ -40,7 +40,7 @@ public:
   /**
    * Constructor for halfspace
    */
-  CSGRegion(std::shared_ptr<CSGSurface> & surf, const CSGSurface::Direction direction);
+  CSGRegion(CSGSurface & surf, const CSGSurface::Direction direction);
 
   /**
    * Constructor for union and intersection
@@ -83,9 +83,9 @@ public:
   /**
    * @brief Get the list of surfaces associated with the region
    *
-   * @return std::vector<std::shared_ptr<CSGSurface>> list of surfaces that define the region
+   * @return std::vector<CSGSurface *> list of pointers to surfaces that define the region
    */
-  std::vector<std::shared_ptr<CSGSurface>> getSurfaces() const { return _surfaces; };
+  std::vector<CSGSurface *> getSurfaces() const { return _surfaces; };
 
   /// Operator overload for &= add an intersection to the current region
   CSGRegion & operator&=(const CSGRegion & other_region);
@@ -101,7 +101,7 @@ protected:
   RegionType _region_type;
 
   /// Surface list associated with the region
-  std::vector<std::shared_ptr<CSGSurface>> _surfaces;
+  std::vector<CSGSurface *> _surfaces;
 };
 
 /**
@@ -116,11 +116,11 @@ std::string stripRegionString(std::string region_str, std::string op);
 
 /// Operation overloads for operation based region construction
 
-// positve halfspace (+)
-const CSGRegion operator+(std::shared_ptr<CSGSurface> surf);
+// positive halfspace (+)
+const CSGRegion operator+(CSGSurface & surf);
 
 // negative halfspace (-)
-const CSGRegion operator-(std::shared_ptr<CSGSurface> surf);
+const CSGRegion operator-(CSGSurface & surf);
 
 // intersection (&)
 const CSGRegion operator&(const CSGRegion & region_a, const CSGRegion & region_b);

--- a/framework/include/csg/CSGSurface.h
+++ b/framework/include/csg/CSGSurface.h
@@ -125,6 +125,12 @@ public:
    */
   std::string getName() const { return _name; }
 
+  /// Operator overload for checking if two CSGSurface objects are equal
+  bool operator==(const CSGSurface & other) const;
+
+  /// Operator overload for checking if two CSGSurface objects are not equal
+  bool operator!=(const CSGSurface & other) const;
+
 protected:
   // set the name of the surface - intentionally not public because
   // name needs to be managed at the CSGSurfaceList level

--- a/framework/include/csg/CSGSurfaceList.h
+++ b/framework/include/csg/CSGSurfaceList.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "CSGSurface.h"
+#include "CSGPlane.h"
 
 namespace CSG
 {
@@ -38,13 +39,13 @@ protected:
    * @param p2 point 2
    * @param p3 point 3
    * @param boundary CSGSurface::BoundaryType boundary type for the surface
-   * @return std::shared_ptr<CSGSurface> pointer to plane surface created
+   * @return CSGSurface & reference to plane surface created
    */
-  std::shared_ptr<CSGSurface> addPlaneFromPoints(const std::string name,
-                                                 const Point p1,
-                                                 const Point p2,
-                                                 const Point p3,
-                                                 CSGSurface::BoundaryType boundary);
+  CSGSurface & addPlaneFromPoints(const std::string name,
+                                  const Point & p1,
+                                  const Point & p2,
+                                  const Point & p3,
+                                  CSGSurface::BoundaryType boundary);
 
   /**
    * @brief Create a new CSGPlane surface from coefficients (a, b, c, d) for the
@@ -56,14 +57,14 @@ protected:
    * @param c coefficient c
    * @param d coefficient d
    * @param boundary CSGSurface::BoundaryType boundary type for the surface
-   * @return std::shared_ptr<CSGSurface> pointer to plane surface created
+   * @return const CSGSurface & reference to plane surface created
    */
-  std::shared_ptr<CSGSurface> addPlaneFromCoefficients(const std::string name,
-                                                       const Real a,
-                                                       const Real b,
-                                                       const Real c,
-                                                       const Real d,
-                                                       CSGSurface::BoundaryType boundary);
+  CSGSurface & addPlaneFromCoefficients(const std::string name,
+                                        const Real a,
+                                        const Real b,
+                                        const Real c,
+                                        const Real d,
+                                        CSGSurface::BoundaryType boundary);
 
   /**
    * @brief create a new CSGSphere surface
@@ -72,12 +73,12 @@ protected:
    * @param center center point of sphere
    * @param r radius of sphere
    * @param boundary CSGSurface::BoundaryType boundary type for the surface
-   * @return std::shared_ptr<CSGSurface> pointer to sphere surface created
+   * @return CSGSurface & reference to sphere surface created
    */
-  std::shared_ptr<CSGSurface> addSphere(const std::string name,
-                                        const Point center,
-                                        const Real r,
-                                        CSGSurface::BoundaryType boundary);
+  CSGSurface & addSphere(const std::string name,
+                         const Point center,
+                         const Real r,
+                         CSGSurface::BoundaryType boundary);
 
   /**
    * @brief create a cylinder aligned with the specified axis
@@ -88,32 +89,36 @@ protected:
    * @param r radius
    * @param axis axis alignment (x, y, or z)
    * @param boundary CSGSurface::BoundaryType boundary type for the surface
-   * @return std::shared_ptr<CSGSurface>
+   * @return reference to CSGSurface object that is created
    */
-  std::shared_ptr<CSGSurface> addCylinder(const std::string name,
-                                          const Real x0,
-                                          const Real x1,
-                                          const Real r,
-                                          const std::string axis,
-                                          CSGSurface::BoundaryType boundary);
+  CSGSurface & addCylinder(const std::string name,
+                           const Real x0,
+                           const Real x1,
+                           const Real r,
+                           const std::string axis,
+                           CSGSurface::BoundaryType boundary);
 
   /**
-   * @brief Get the all aurfaces
+   * @brief Get map of all names to surfaces in surface list
    *
-   * @return const std::map<std::string, std::shared_ptr<CSGSurface>>& map of all names to surfaces
+   * @return std::map<std::string, std::shared_ptr<CSGSurface>>& map of all names to surfaces
    */
-  const std::map<std::string, std::shared_ptr<CSGSurface>> & getAllSurfaces() const
-  {
-    return _surfaces;
-  }
+  std::map<std::string, std::shared_ptr<CSGSurface>> & getSurfaceListMap() { return _surfaces; }
+
+  /**
+   * @brief Get list of pointers to all surfaces in surface list
+   *
+   * @return std::vector<CSGSurface *> list of pointers to surfaces
+   */
+  std::vector<CSGSurface *> getAllSurfaces() const;
 
   /**
    * @brief Get a surface by name
    *
    * @param name name of surface
-   * @return const std::shared_ptr<CSGSurface>& pointer to CSGSurface of the specified name
+   * @return CSGSurface & reference to CSGSurface of the specified name
    */
-  const std::shared_ptr<CSGSurface> & getSurface(const std::string name) const;
+  CSGSurface & getSurface(const std::string name) const;
 
   /**
    * @brief add a surface object to existing SurfaceList
@@ -123,11 +128,11 @@ protected:
   void addSurface(const std::shared_ptr<CSGSurface> surf);
 
   /**
-   * @brief rename the specified cell
+   * @brief rename the specified surface
    *
    * @param name new name of surface
    */
-  void renameSurface(const std::shared_ptr<CSGSurface> surface, const std::string name);
+  void renameSurface(CSGSurface & surface, const std::string name);
 
   /// Checks whether surface name already exists within CSGSurfaceList object
   void checkSurfaceName(const std::string name) const;

--- a/framework/include/csg/CSGSurfaceList.h
+++ b/framework/include/csg/CSGSurfaceList.h
@@ -106,11 +106,11 @@ protected:
   std::map<std::string, std::unique_ptr<CSGSurface>> & getSurfaceListMap() { return _surfaces; }
 
   /**
-   * @brief Get list of pointers to all surfaces in surface list
+   * @brief Get list of references to all surfaces in surface list
    *
-   * @return std::vector<CSGSurface *> list of pointers to surfaces
+   * @return std::vector<std::reference_wrapper<const CSGSurface>> list of references to surfaces
    */
-  std::vector<CSGSurface *> getAllSurfaces() const;
+  std::vector<std::reference_wrapper<const CSGSurface>> getAllSurfaces() const;
 
   /**
    * @brief Get a surface by name

--- a/framework/include/csg/CSGSurfaceList.h
+++ b/framework/include/csg/CSGSurfaceList.h
@@ -133,7 +133,7 @@ protected:
    *
    * @param name new name of surface
    */
-  void renameSurface(CSGSurface & surface, const std::string name);
+  void renameSurface(const CSGSurface & surface, const std::string name);
 
   /// Checks whether surface name already exists within CSGSurfaceList object
   void checkSurfaceName(const std::string name) const;

--- a/framework/include/csg/CSGSurfaceList.h
+++ b/framework/include/csg/CSGSurfaceList.h
@@ -101,9 +101,9 @@ protected:
   /**
    * @brief Get map of all names to surfaces in surface list
    *
-   * @return std::map<std::string, std::shared_ptr<CSGSurface>>& map of all names to surfaces
+   * @return std::map<std::string, std::unique_ptr<CSGSurface>>& map of all names to surfaces
    */
-  std::map<std::string, std::shared_ptr<CSGSurface>> & getSurfaceListMap() { return _surfaces; }
+  std::map<std::string, std::unique_ptr<CSGSurface>> & getSurfaceListMap() { return _surfaces; }
 
   /**
    * @brief Get list of pointers to all surfaces in surface list
@@ -121,11 +121,12 @@ protected:
   CSGSurface & getSurface(const std::string name) const;
 
   /**
-   * @brief add a surface object to existing SurfaceList
+   * @brief add a surface object to existing SurfaceList. Ownership of surface will be transferred
+   * to surface list object that calls this function
    *
    * @param surf CSGSurface to add
    */
-  void addSurface(const std::shared_ptr<CSGSurface> surf);
+  void addSurface(std::unique_ptr<CSGSurface> & surf);
 
   /**
    * @brief rename the specified surface
@@ -138,7 +139,7 @@ protected:
   void checkSurfaceName(const std::string name) const;
 
   /// Mapping of surface names to pointers of stored surface objects
-  std::map<std::string, std::shared_ptr<CSGSurface>> _surfaces;
+  std::map<std::string, std::unique_ptr<CSGSurface>> _surfaces;
 
   // Only CSGBase should be calling the methods in CSGSurfaceList
   friend class CSGBase;

--- a/framework/include/csg/CSGUniverse.h
+++ b/framework/include/csg/CSGUniverse.h
@@ -37,9 +37,7 @@ public:
    * @param cells list of cells to add to universe
    * @param is_root true to set universe as the root universe (default false)
    */
-  CSGUniverse(const std::string name,
-              std::vector<std::shared_ptr<CSGCell>> & cells,
-              bool is_root = false);
+  CSGUniverse(const std::string name, std::vector<CSGCell *> & cells, bool is_root = false);
 
   /**
    * Destructor
@@ -50,9 +48,9 @@ public:
    * @brief Get the Cell object by name
    *
    * @param name name of cell
-   * @return std::shared_ptr<CSGCell> pointer to the cell of the specified name in this universe
+   * @return CSGCell & reference to the cell of the specified name in this universe
    */
-  const std::shared_ptr<CSGCell> & getCell(const std::string name);
+  CSGCell & getCell(const std::string name);
 
   /**
    * @brief check if cell of provided name is present in universe
@@ -65,9 +63,9 @@ public:
   /**
    * @brief Get list of the all cells in the universe
    *
-   * @return std::vector<std::shared_ptr<CSGCell>> list of pointers to cells in universe
+   * @return std::vector<CSGCell *> list of pointers to cells in universe
    */
-  const std::vector<std::shared_ptr<CSGCell>> & getAllCells() const { return _cells; }
+  const std::vector<CSGCell *> & getAllCells() const { return _cells; }
 
   /**
    * @brief Get the name of the universe
@@ -83,13 +81,19 @@ public:
    */
   bool isRoot() const { return _is_root; }
 
+  /// Operator overload for checking if two CSGUniverse objects are equal
+  bool operator==(const CSGUniverse & other) const;
+
+  /// Operator overload for checking if two CSGUniverse objects are not equal
+  bool operator!=(const CSGUniverse & other) const;
+
 protected:
   /**
    * @brief add cell to universe
    *
-   * @param cell pointer to cell to add
+   * @param reference to cell to add
    */
-  void addCell(const std::shared_ptr<CSGCell> & cell);
+  void addCell(CSGCell & cell);
 
   /**
    * @brief remove a cell of the specified name from the universe
@@ -110,8 +114,8 @@ protected:
   /// Name of universe
   std::string _name;
 
-  /// list of cells in universe
-  std::vector<std::shared_ptr<CSGCell>> _cells;
+  /// list of pointers to cells in universe
+  std::vector<CSGCell *> _cells;
 
   // whether or not this universe is the root universe
   bool _is_root;

--- a/framework/include/csg/CSGUniverse.h
+++ b/framework/include/csg/CSGUniverse.h
@@ -48,9 +48,9 @@ public:
    * @brief Get the Cell object by name
    *
    * @param name name of cell
-   * @return CSGCell & reference to the cell of the specified name in this universe
+   * @return const CSGCell & reference to the cell of the specified name in this universe
    */
-  CSGCell & getCell(const std::string name);
+  const CSGCell & getCell(const std::string name);
 
   /**
    * @brief check if cell of provided name is present in universe
@@ -65,7 +65,7 @@ public:
    *
    * @return std::vector<CSGCell *> list of pointers to cells in universe
    */
-  const std::vector<CSGCell *> & getAllCells() const { return _cells; }
+  const std::vector<const CSGCell *> & getAllCells() const { return _cells; }
 
   /**
    * @brief Get the name of the universe
@@ -93,7 +93,7 @@ protected:
    *
    * @param reference to cell to add
    */
-  void addCell(CSGCell & cell);
+  void addCell(const CSGCell & cell);
 
   /**
    * @brief remove a cell of the specified name from the universe
@@ -115,7 +115,7 @@ protected:
   std::string _name;
 
   /// list of pointers to cells in universe
-  std::vector<CSGCell *> _cells;
+  std::vector<const CSGCell *> _cells;
 
   // whether or not this universe is the root universe
   bool _is_root;

--- a/framework/include/csg/CSGUniverse.h
+++ b/framework/include/csg/CSGUniverse.h
@@ -65,7 +65,7 @@ public:
    *
    * @return std::vector<CSGCell *> list of pointers to cells in universe
    */
-  const std::vector<const CSGCell *> & getAllCells() const { return _cells; }
+  const std::vector<std::reference_wrapper<const CSGCell>> & getAllCells() const { return _cells; }
 
   /**
    * @brief Get the name of the universe
@@ -114,8 +114,8 @@ protected:
   /// Name of universe
   std::string _name;
 
-  /// list of pointers to cells in universe
-  std::vector<const CSGCell *> _cells;
+  /// list of references to cells in universe
+  std::vector<std::reference_wrapper<const CSGCell>> _cells;
 
   // whether or not this universe is the root universe
   bool _is_root;

--- a/framework/include/csg/CSGUniverseList.h
+++ b/framework/include/csg/CSGUniverseList.h
@@ -50,10 +50,10 @@ protected:
   /**
    * @brief Get map of all names to universes in universe list
    *
-   * @return std::map<std::string, std::shared_ptr<CSGUniverse>>& map of all names to
+   * @return std::map<std::string, std::unique_ptr<CSGUniverse>>& map of all names to
    * universes
    */
-  std::map<std::string, std::shared_ptr<CSGUniverse>> & getUniverseListMap() { return _universes; }
+  std::map<std::string, std::unique_ptr<CSGUniverse>> & getUniverseListMap() { return _universes; }
 
   /**
    * @brief Get the all universes in CSGBase instance
@@ -78,11 +78,12 @@ protected:
   CSGUniverse & getRoot() { return *_root_universe; };
 
   /**
-   * @brief add an existing universe to list
+   * @brief add an existing universe to list. Ownership of universe will be transferred to universe
+   * list object that calls this function
    *
-   * @param universe shared_ptr to universe to add
+   * @param universe unique_ptr to universe to add
    */
-  void addUniverse(std::shared_ptr<CSGUniverse> & universe);
+  void addUniverse(std::unique_ptr<CSGUniverse> & universe);
 
   /**
    * @brief rename the specified universe
@@ -96,10 +97,10 @@ protected:
   void checkUniverseName(const std::string name) const;
 
   /// Mapping of universe names to pointers of stored universe objects
-  std::map<std::string, std::shared_ptr<CSGUniverse>> _universes;
+  std::map<std::string, std::unique_ptr<CSGUniverse>> _universes;
 
   /// root universe for the CSGBase instance
-  std::shared_ptr<CSGUniverse> _root_universe;
+  CSGUniverse * _root_universe;
 
   // Only CSGBase should be calling the methods in CSGUniverseList
   friend class CSGBase;

--- a/framework/include/csg/CSGUniverseList.h
+++ b/framework/include/csg/CSGUniverseList.h
@@ -34,59 +34,63 @@ protected:
    * @brief create an empty universe
    *
    * @param name unique name of universe
-   * @return std::shared_ptr<CSGUniverse> pointer to empty universe that is created
+   * @return CSGUniverse & reference to empty universe that is created
    */
-  const std::shared_ptr<CSGUniverse> & addUniverse(const std::string name);
+  CSGUniverse & addUniverse(const std::string name);
 
   /**
    * @brief create a universe from list of cells
    *
    * @param name unique name of universe
    * @param cells list of cell pointers to add to the universe upon creation
-   * @return std::shared_ptr<CSGUniverse> pointer to universe that is created
+   * @return CSGUniverse & pointer to universe that is created
    */
-  const std::shared_ptr<CSGUniverse> & addUniverse(const std::string name,
-                                                   std::vector<std::shared_ptr<CSGCell>> & cells);
+  CSGUniverse & addUniverse(const std::string name, std::vector<CSGCell *> & cells);
 
   /**
-   * @brief Get the all universes
+   * @brief Get map of all names to universes in universe list
    *
-   * @return const std::map<std::string, std::shared_ptr<CSGUniverse>>& map of all names to
+   * @return std::map<std::string, std::shared_ptr<CSGUniverse>>& map of all names to
    * universes
    */
-  const std::map<std::string, std::shared_ptr<CSGUniverse>> & getAllUniverses() const
-  {
-    return _universes;
-  }
+  std::map<std::string, std::shared_ptr<CSGUniverse>> & getUniverseListMap() { return _universes; }
+
+  /**
+   * @brief Get the all universes in CSGBase instance
+   *
+   * @return std::vector<CSGUniverse *> list of pointers to all CSGUniverse objects
+   */
+  std::vector<CSGUniverse *> getAllUniverses() const;
 
   /**
    * @brief Get the Universe by name
    *
    * @param name name of universe
-   * @return const std::shared_ptr<CSGUniverse>& pointer to CSGUniverse of the specified name
+   * @return CSGUniverse & reference to CSGUniverse of the specified name
    */
-  const std::shared_ptr<CSGUniverse> & getUniverse(const std::string name) const;
+  CSGUniverse & getUniverse(const std::string name);
 
   /**
    * @brief Get the root universe
    *
-   * @return const std::shared_ptr<CSGUniverse>& pointer to the root universe
+   * @return CSGUniverse & reference to the root universe
    */
-  const std::shared_ptr<CSGUniverse> & getRoot() const { return _root_universe; };
+  CSGUniverse & getRoot() { return *_root_universe; };
 
   /**
    * @brief add an existing universe to list
    *
-   * @param universe
+   * @param universe shared_ptr to universe to add
    */
-  void addUniverse(const std::shared_ptr<CSGUniverse> & universe);
+  void addUniverse(std::shared_ptr<CSGUniverse> & universe);
 
   /**
    * @brief rename the specified universe
    *
+   * @param universe reference to universe whose name should be renamed
    * @param name new name
    */
-  void renameUniverse(const std::shared_ptr<CSGUniverse> & universe, const std::string name);
+  void renameUniverse(CSGUniverse & universe, const std::string name);
 
   /// Checks whether universe name already exists within CSGUniverseList object
   void checkUniverseName(const std::string name) const;

--- a/framework/include/csg/CSGUniverseList.h
+++ b/framework/include/csg/CSGUniverseList.h
@@ -75,7 +75,7 @@ protected:
    *
    * @return CSGUniverse & reference to the root universe
    */
-  CSGUniverse & getRoot() { return *_root_universe; };
+  const CSGUniverse & getRoot() const { return *_root_universe; };
 
   /**
    * @brief add an existing universe to list. Ownership of universe will be transferred to universe
@@ -91,7 +91,7 @@ protected:
    * @param universe reference to universe whose name should be renamed
    * @param name new name
    */
-  void renameUniverse(CSGUniverse & universe, const std::string name);
+  void renameUniverse(const CSGUniverse & universe, const std::string name);
 
   /// Checks whether universe name already exists within CSGUniverseList object
   void checkUniverseName(const std::string name) const;
@@ -100,7 +100,7 @@ protected:
   std::map<std::string, std::unique_ptr<CSGUniverse>> _universes;
 
   /// root universe for the CSGBase instance
-  CSGUniverse * _root_universe;
+  const CSGUniverse * _root_universe;
 
   // Only CSGBase should be calling the methods in CSGUniverseList
   friend class CSGBase;

--- a/framework/include/csg/CSGUniverseList.h
+++ b/framework/include/csg/CSGUniverseList.h
@@ -58,9 +58,10 @@ protected:
   /**
    * @brief Get the all universes in CSGBase instance
    *
-   * @return std::vector<CSGUniverse *> list of pointers to all CSGUniverse objects
+   * @return std::vector<std::reference_wrapper<const CSGUniverse> list of references to all
+   * CSGUniverse objects
    */
-  std::vector<CSGUniverse *> getAllUniverses() const;
+  std::vector<std::reference_wrapper<const CSGUniverse>> getAllUniverses() const;
 
   /**
    * @brief Get the Universe by name

--- a/framework/src/csg/CSGBase.C
+++ b/framework/src/csg/CSGBase.C
@@ -124,7 +124,7 @@ CSGBase::joinSurfaceList(CSGSurfaceList & surf_list)
   // adding if duplicate; must update references to the surface in cell
   // region definitions.
   auto & surf_list_map = surf_list.getSurfaceListMap();
-  for (auto s : surf_list_map)
+  for (auto & s : surf_list_map)
     _surface_list.addSurface(s.second);
 }
 

--- a/framework/src/csg/CSGBase.C
+++ b/framework/src/csg/CSGBase.C
@@ -129,8 +129,8 @@ CSGBase::joinSurfaceList(CSGSurfaceList & surf_list)
   // TODO: check if surface is a duplicate (by definition) and skip
   // adding if duplicate; must update references to the surface in cell
   // region definitions.
-  auto all_surfs = surf_list.getAllSurfaces();
-  for (auto s : all_surfs)
+  auto & surf_list_map = surf_list.getSurfaceListMap();
+  for (auto s : surf_list_map)
     _surface_list.addSurface(s.second);
 }
 
@@ -218,10 +218,10 @@ CSGBase::checkRegionSurfaces(const CSGRegion & region)
   {
     auto sname = s->getName();
     // if there is no surface by this name at all, there will be an error from getSurface
-    auto list_surf = _surface_list.getSurface(s->getName());
+    const auto & list_surf = _surface_list.getSurface(s->getName());
     // if there is a surface by the same name, check that it is actually the surface being used
     // (ie same surface points to same location in memory)
-    if (s != list_surf)
+    if (*s != list_surf)
       mooseError("Region is being set with a surface named " + sname +
                  " that is different from the surface of the same name in the base instance.");
   }
@@ -280,13 +280,13 @@ CSGBase::generateOutput() const
   auto all_surfs = getAllSurfaces();
   for (const auto & s : all_surfs)
   {
-    auto surf_obj = s.second;
-    auto coeffs = surf_obj->getCoeffs();
-    csg_json["SURFACES"][s.first] = {{"TYPE", surf_obj->getSurfaceTypeString()},
-                                     {"BOUNDARY", surf_obj->getBoundaryTypeString()},
-                                     {"COEFFICIENTS", {}}};
+    auto surf_name = s->getName();
+    auto coeffs = s->getCoeffs();
+    csg_json["SURFACES"][surf_name] = {{"TYPE", s->getSurfaceTypeString()},
+                                       {"BOUNDARY", s->getBoundaryTypeString()},
+                                       {"COEFFICIENTS", {}}};
     for (const auto & c : coeffs)
-      csg_json["SURFACES"][s.first]["COEFFICIENTS"][c.first] = c.second;
+      csg_json["SURFACES"][surf_name]["COEFFICIENTS"][c.first] = c.second;
   }
 
   // Print out cell information

--- a/framework/src/csg/CSGCell.C
+++ b/framework/src/csg/CSGCell.C
@@ -23,9 +23,7 @@ CSGCell::CSGCell(const std::string name, const std::string mat_name, const CSGRe
 {
 }
 
-CSGCell::CSGCell(const std::string name,
-                 const std::shared_ptr<CSGUniverse> univ,
-                 const CSGRegion & region)
+CSGCell::CSGCell(const std::string name, CSGUniverse * univ, const CSGRegion & region)
   : _name(name),
     _fill_type(FillType::UNIVERSE),
     _fill_name(univ->getName()),
@@ -34,7 +32,7 @@ CSGCell::CSGCell(const std::string name,
 {
 }
 
-const std::shared_ptr<CSGUniverse> &
+const CSGUniverse &
 CSGCell::getFillUniverse() const
 {
   if (getFillType() != FillType::UNIVERSE)
@@ -42,7 +40,7 @@ CSGCell::getFillUniverse() const
     mooseError("Cell '" + getName() + "' has " + getFillTypeString() + " fill, not UNIVERSE.");
   }
   else
-    return _fill_universe;
+    return *_fill_universe;
 }
 
 const std::string
@@ -69,4 +67,34 @@ CSGCell::getFillTypeString() const
       return "VOID";
   }
 }
+
+bool
+CSGCell::operator==(const CSG::CSGCell & other) const
+{
+  const auto name_eq = this->getName() == other.getName();
+  const auto region_eq = this->getRegion() == other.getRegion();
+  const auto fill_type_eq = (this->getFillTypeString() == other.getFillTypeString()) &&
+                            (this->getFillName() == other.getFillName());
+  if (name_eq && region_eq && fill_type_eq)
+  {
+    switch (this->getFillType())
+    {
+      case FillType::MATERIAL:
+        return this->getFillMaterial() == other.getFillMaterial();
+      case FillType::UNIVERSE:
+        return this->getFillUniverse() == other.getFillUniverse();
+      default:
+        return true;
+    }
+  }
+  else
+    return false;
+}
+
+bool
+CSGCell::operator!=(const CSG::CSGCell & other) const
+{
+  return !(*this == other);
+}
+
 } // namespace CSG

--- a/framework/src/csg/CSGCell.C
+++ b/framework/src/csg/CSGCell.C
@@ -23,7 +23,7 @@ CSGCell::CSGCell(const std::string name, const std::string mat_name, const CSGRe
 {
 }
 
-CSGCell::CSGCell(const std::string name, CSGUniverse * univ, const CSGRegion & region)
+CSGCell::CSGCell(const std::string name, const CSGUniverse * univ, const CSGRegion & region)
   : _name(name),
     _fill_type(FillType::UNIVERSE),
     _fill_name(univ->getName()),

--- a/framework/src/csg/CSGCellList.C
+++ b/framework/src/csg/CSGCellList.C
@@ -34,7 +34,7 @@ CSGCell &
 CSGCellList::addVoidCell(const std::string name, const CSGRegion & region)
 {
   checkCellName(name);
-  _cells.insert(std::make_pair(name, std::make_shared<CSGCell>(name, region)));
+  _cells.insert(std::make_pair(name, std::make_unique<CSGCell>(name, region)));
   return *_cells[name];
 }
 
@@ -44,7 +44,7 @@ CSGCellList::addMaterialCell(const std::string name,
                              const CSGRegion & region)
 {
   checkCellName(name);
-  _cells.insert(std::make_pair(name, std::make_shared<CSGCell>(name, mat_name, region)));
+  _cells.insert(std::make_pair(name, std::make_unique<CSGCell>(name, mat_name, region)));
   return *_cells[name];
 }
 
@@ -52,7 +52,7 @@ CSGCell &
 CSGCellList::addUniverseCell(const std::string name, CSGUniverse & univ, const CSGRegion & region)
 {
   checkCellName(name);
-  _cells.insert(std::make_pair(name, std::make_shared<CSGCell>(name, &univ, region)));
+  _cells.insert(std::make_pair(name, std::make_unique<CSGCell>(name, &univ, region)));
   return *_cells[name];
 }
 
@@ -66,11 +66,11 @@ CSGCellList::getAllCells() const
 }
 
 void
-CSGCellList::addCell(std::shared_ptr<CSGCell> & cell)
+CSGCellList::addCell(std::unique_ptr<CSGCell> & cell)
 {
   auto name = cell->getName();
   checkCellName(name);
-  _cells.insert(std::make_pair(name, cell));
+  _cells.insert(std::make_pair(name, std::move(cell)));
 }
 
 void
@@ -78,7 +78,7 @@ CSGCellList::renameCell(CSGCell & cell, const std::string name)
 {
   // check that this cell passed in is actually in the same cell that is in the cell list
   auto prev_name = cell.getName();
-  auto existing_cell = _cells.find(prev_name)->second;
+  auto existing_cell = std::move(_cells.find(prev_name)->second);
   if (*existing_cell != cell)
     mooseError("Cell " + prev_name + " cannot be renamed to " + name +
                " as it does not exist in this CSGBase instance.");
@@ -86,7 +86,7 @@ CSGCellList::renameCell(CSGCell & cell, const std::string name)
   checkCellName(name);
   existing_cell->setName(name);
   _cells.erase(prev_name);
-  _cells.insert(std::make_pair(name, existing_cell));
+  _cells.insert(std::make_pair(name, std::move(existing_cell)));
 }
 
 } // namespace CSG

--- a/framework/src/csg/CSGCellList.C
+++ b/framework/src/csg/CSGCellList.C
@@ -58,12 +58,12 @@ CSGCellList::addUniverseCell(const std::string name,
   return *_cells[name];
 }
 
-std::vector<CSGCell *>
+std::vector<std::reference_wrapper<const CSGCell>>
 CSGCellList::getAllCells() const
 {
-  std::vector<CSGCell *> cells;
+  std::vector<std::reference_wrapper<const CSGCell>> cells;
   for (auto it = _cells.begin(); it != _cells.end(); ++it)
-    cells.push_back(it->second.get());
+    cells.push_back(*(it->second));
   return cells;
 }
 

--- a/framework/src/csg/CSGCellList.C
+++ b/framework/src/csg/CSGCellList.C
@@ -49,7 +49,9 @@ CSGCellList::addMaterialCell(const std::string name,
 }
 
 CSGCell &
-CSGCellList::addUniverseCell(const std::string name, CSGUniverse & univ, const CSGRegion & region)
+CSGCellList::addUniverseCell(const std::string name,
+                             const CSGUniverse & univ,
+                             const CSGRegion & region)
 {
   checkCellName(name);
   _cells.insert(std::make_pair(name, std::make_unique<CSGCell>(name, &univ, region)));
@@ -74,7 +76,7 @@ CSGCellList::addCell(std::unique_ptr<CSGCell> & cell)
 }
 
 void
-CSGCellList::renameCell(CSGCell & cell, const std::string name)
+CSGCellList::renameCell(const CSGCell & cell, const std::string name)
 {
   // check that this cell passed in is actually in the same cell that is in the cell list
   auto prev_name = cell.getName();

--- a/framework/src/csg/CSGRegion.C
+++ b/framework/src/csg/CSGRegion.C
@@ -178,4 +178,19 @@ operator~(const CSGRegion & region)
   return CSGRegion(region, CSGRegion::RegionType::COMPLEMENT);
 }
 
+bool
+CSGRegion::operator==(const CSGRegion & other) const
+{
+  const bool region_type_eq = this->getRegionType() == other.getRegionType();
+  const bool region_str_eq = this->toString() == other.toString();
+  const bool surfaces_eq = this->getSurfaces() == other.getSurfaces();
+  return region_type_eq && region_str_eq && surfaces_eq;
+}
+
+bool
+CSGRegion::operator!=(const CSGRegion & other) const
+{
+  return !(*this == other);
+}
+
 } // namespace CSG

--- a/framework/src/csg/CSGRegion.C
+++ b/framework/src/csg/CSGRegion.C
@@ -19,11 +19,11 @@ CSGRegion::CSGRegion()
 }
 
 // halfspace constructor
-CSGRegion::CSGRegion(std::shared_ptr<CSGSurface> & surf, const CSGSurface::Direction direction)
+CSGRegion::CSGRegion(CSGSurface & surf, const CSGSurface::Direction direction)
   : _region_type(CSGRegion::RegionType::HALFSPACE)
 {
-  _region_str = ((direction == CSGSurface::Direction::POSITIVE) ? "+" : "-") + surf->getName();
-  _surfaces.push_back(surf);
+  _region_str = ((direction == CSGSurface::Direction::POSITIVE) ? "+" : "-") + surf.getName();
+  _surfaces.push_back(&surf);
 }
 
 // intersection and union constructor
@@ -46,8 +46,8 @@ CSGRegion::CSGRegion(const CSGRegion & region_a,
     auto b_string = stripRegionString(region_b.toString(), op);
 
     _region_str = "(" + a_string + op + b_string + ")";
-    auto a_surfs = region_a.getSurfaces();
-    auto b_surfs = region_b.getSurfaces();
+    const auto & a_surfs = region_a.getSurfaces();
+    const auto & b_surfs = region_b.getSurfaces();
     _surfaces.insert(_surfaces.end(), a_surfs.begin(), a_surfs.end());
     _surfaces.insert(_surfaces.end(), b_surfs.begin(), b_surfs.end());
   }
@@ -143,16 +143,16 @@ stripRegionString(std::string region_str, std::string op)
 
 // Operators for region construction
 
-// positve halfspace
+// positive halfspace
 const CSGRegion
-operator+(std::shared_ptr<CSGSurface> surf)
+operator+(CSGSurface & surf)
 {
   return CSGRegion(surf, CSGSurface::Direction::POSITIVE);
 }
 
 // negative halfspace
 const CSGRegion
-operator-(std::shared_ptr<CSGSurface> surf)
+operator-(CSGSurface & surf)
 {
   return CSGRegion(surf, CSGSurface::Direction::NEGATIVE);
 }

--- a/framework/src/csg/CSGRegion.C
+++ b/framework/src/csg/CSGRegion.C
@@ -19,7 +19,7 @@ CSGRegion::CSGRegion()
 }
 
 // halfspace constructor
-CSGRegion::CSGRegion(CSGSurface & surf, const CSGSurface::Direction direction)
+CSGRegion::CSGRegion(const CSGSurface & surf, const CSGSurface::Direction direction)
   : _region_type(CSGRegion::RegionType::HALFSPACE)
 {
   _region_str = ((direction == CSGSurface::Direction::POSITIVE) ? "+" : "-") + surf.getName();
@@ -145,14 +145,14 @@ stripRegionString(std::string region_str, std::string op)
 
 // positive halfspace
 const CSGRegion
-operator+(CSGSurface & surf)
+operator+(const CSGSurface & surf)
 {
   return CSGRegion(surf, CSGSurface::Direction::POSITIVE);
 }
 
 // negative halfspace
 const CSGRegion
-operator-(CSGSurface & surf)
+operator-(const CSGSurface & surf)
 {
   return CSGRegion(surf, CSGSurface::Direction::NEGATIVE);
 }

--- a/framework/src/csg/CSGRegion.C
+++ b/framework/src/csg/CSGRegion.C
@@ -23,7 +23,7 @@ CSGRegion::CSGRegion(const CSGSurface & surf, const CSGSurface::Direction direct
   : _region_type(CSGRegion::RegionType::HALFSPACE)
 {
   _region_str = ((direction == CSGSurface::Direction::POSITIVE) ? "+" : "-") + surf.getName();
-  _surfaces.push_back(&surf);
+  _surfaces.push_back(surf);
 }
 
 // intersection and union constructor
@@ -183,8 +183,23 @@ CSGRegion::operator==(const CSGRegion & other) const
 {
   const bool region_type_eq = this->getRegionType() == other.getRegionType();
   const bool region_str_eq = this->toString() == other.toString();
-  const bool surfaces_eq = this->getSurfaces() == other.getSurfaces();
-  return region_type_eq && region_str_eq && surfaces_eq;
+  if (region_type_eq && region_str_eq)
+  {
+    const auto & all_surfs = getSurfaces();
+    const auto & other_surfs = other.getSurfaces();
+    const bool num_cells_eq = all_surfs.size() == other_surfs.size();
+    if (num_cells_eq)
+    {
+      for (unsigned int i = 0; i < all_surfs.size(); ++i)
+        if (all_surfs[i].get() != other_surfs[i].get())
+          return false;
+      return true;
+    }
+    else
+      return false;
+  }
+  else
+    return false;
 }
 
 bool

--- a/framework/src/csg/CSGSurface.C
+++ b/framework/src/csg/CSGSurface.C
@@ -55,4 +55,20 @@ CSGSurface::getBoundaryTypeString() const
   }
 }
 
+bool
+CSGSurface::operator==(const CSGSurface & other) const
+{
+  const auto name_eq = this->getName() == other.getName();
+  const auto boundary_type_eq = this->getBoundaryType() == other.getBoundaryType();
+  const auto surface_type_eq = this->getSurfaceType() == other.getSurfaceType();
+  const auto coeffs_eq = this->getCoeffs() == other.getCoeffs();
+  return (name_eq && boundary_type_eq && surface_type_eq && coeffs_eq);
+}
+
+bool
+CSGSurface::operator!=(const CSGSurface & other) const
+{
+  return !(*this == other);
+}
+
 } // namespace CSG

--- a/framework/src/csg/CSGSurfaceList.C
+++ b/framework/src/csg/CSGSurfaceList.C
@@ -96,12 +96,12 @@ CSGSurfaceList::addCylinder(const std::string name,
   return *_surfaces[name];
 }
 
-std::vector<CSGSurface *>
+std::vector<std::reference_wrapper<const CSGSurface>>
 CSGSurfaceList::getAllSurfaces() const
 {
-  std::vector<CSGSurface *> surfaces;
+  std::vector<std::reference_wrapper<const CSGSurface>> surfaces;
   for (auto it = _surfaces.begin(); it != _surfaces.end(); ++it)
-    surfaces.push_back(it->second.get());
+    surfaces.push_back(*(it->second));
   return surfaces;
 }
 

--- a/framework/src/csg/CSGSurfaceList.C
+++ b/framework/src/csg/CSGSurfaceList.C
@@ -114,7 +114,7 @@ CSGSurfaceList::addSurface(std::unique_ptr<CSGSurface> & surf)
 }
 
 void
-CSGSurfaceList::renameSurface(CSGSurface & surface, const std::string name)
+CSGSurfaceList::renameSurface(const CSGSurface & surface, const std::string name)
 {
   // check that this surface passed in is actually in the same surface that is in the surface
   // list

--- a/framework/src/csg/CSGUniverse.C
+++ b/framework/src/csg/CSGUniverse.C
@@ -22,7 +22,7 @@ CSGUniverse::CSGUniverse(const std::string name, std::vector<CSGCell *> & cells,
 }
 
 void
-CSGUniverse::addCell(CSGCell & cell)
+CSGUniverse::addCell(const CSGCell & cell)
 {
   auto cell_name = cell.getName();
   if (!hasCell(cell_name))
@@ -32,7 +32,7 @@ CSGUniverse::addCell(CSGCell & cell)
                  "Skipping cell insertion for cell with duplicate name.");
 }
 
-CSGCell &
+const CSGCell &
 CSGUniverse::getCell(const std::string name)
 {
   if (!hasCell(name))

--- a/framework/src/csg/CSGUniverse.C
+++ b/framework/src/csg/CSGUniverse.C
@@ -14,27 +14,25 @@ namespace CSG
 
 CSGUniverse::CSGUniverse(const std::string name, bool is_root) : _name(name), _is_root(is_root) {}
 
-CSGUniverse::CSGUniverse(const std::string name,
-                         std::vector<std::shared_ptr<CSGCell>> & cells,
-                         bool is_root)
+CSGUniverse::CSGUniverse(const std::string name, std::vector<CSGCell *> & cells, bool is_root)
   : _name(name), _is_root(is_root)
 {
   for (auto cell : cells)
-    addCell(cell);
+    addCell(*cell);
 }
 
 void
-CSGUniverse::addCell(const std::shared_ptr<CSGCell> & cell)
+CSGUniverse::addCell(CSGCell & cell)
 {
-  auto cell_name = cell->getName();
+  auto cell_name = cell.getName();
   if (!hasCell(cell_name))
-    _cells.push_back(cell);
+    _cells.push_back(&cell);
   else
     mooseWarning("Universe " + getName() + " already contains a cell by name " + cell_name + ". " +
                  "Skipping cell insertion for cell with duplicate name.");
 }
 
-const std::shared_ptr<CSGCell> &
+CSGCell &
 CSGUniverse::getCell(const std::string name)
 {
   if (!hasCell(name))
@@ -42,7 +40,7 @@ CSGUniverse::getCell(const std::string name)
   for (const auto & cell : _cells)
   {
     if (cell->getName() == name)
-      return cell;
+      return *cell;
   }
   mooseError("Cell with name " + name + " was not found in universe " + _name + ".");
 }
@@ -73,4 +71,17 @@ CSGUniverse::removeCell(const std::string name)
     }
   }
 }
+
+bool
+CSGUniverse::operator==(const CSGUniverse & other) const
+{
+  return (this->getAllCells() == other.getAllCells()) && this->getName() == other.getName();
+}
+
+bool
+CSGUniverse::operator!=(const CSGUniverse & other) const
+{
+  return !(*this == other);
+}
+
 } // namespace CSG

--- a/framework/src/csg/CSGUniverse.C
+++ b/framework/src/csg/CSGUniverse.C
@@ -26,7 +26,7 @@ CSGUniverse::addCell(const CSGCell & cell)
 {
   auto cell_name = cell.getName();
   if (!hasCell(cell_name))
-    _cells.push_back(&cell);
+    _cells.push_back(cell);
   else
     mooseWarning("Universe " + getName() + " already contains a cell by name " + cell_name + ". " +
                  "Skipping cell insertion for cell with duplicate name.");
@@ -37,22 +37,18 @@ CSGUniverse::getCell(const std::string name)
 {
   if (!hasCell(name))
     mooseError("Cell with name " + name + " does not exist in universe " + _name + ".");
-  for (const auto & cell : _cells)
-  {
-    if (cell->getName() == name)
-      return *cell;
-  }
+  for (const CSGCell & cell : _cells)
+    if (cell.getName() == name)
+      return cell;
   mooseError("Cell with name " + name + " was not found in universe " + _name + ".");
 }
 
 bool
 CSGUniverse::hasCell(const std::string name) const
 {
-  for (auto cell : _cells)
-  {
-    if (cell->getName() == name)
+  for (const CSGCell & cell : _cells)
+    if (cell.getName() == name)
       return true;
-  }
   return false;
 }
 
@@ -62,20 +58,35 @@ CSGUniverse::removeCell(const std::string name)
   if (!hasCell(name))
     mooseError("Cannot remove cell. Cell with name " + name + " does not exist in universe " +
                _name + ".");
-  for (auto cell : _cells)
-  {
-    if (cell->getName() == name)
+  for (auto it = _cells.begin(); it != _cells.end(); ++it)
+    if (it->get().getName() == name)
     {
-      _cells.erase(std::remove(_cells.begin(), _cells.end(), cell), _cells.end());
+      _cells.erase(it);
       break;
     }
-  }
 }
 
 bool
 CSGUniverse::operator==(const CSGUniverse & other) const
 {
-  return (this->getAllCells() == other.getAllCells()) && this->getName() == other.getName();
+  const bool names_eq = this->getName() == other.getName();
+  if (names_eq)
+  {
+    const auto & all_cells = getAllCells();
+    const auto & other_cells = other.getAllCells();
+    const bool num_cells_eq = all_cells.size() == other_cells.size();
+    if (num_cells_eq)
+    {
+      for (unsigned int i = 0; i < all_cells.size(); ++i)
+        if (all_cells[i].get() != other_cells[i].get())
+          return false;
+      return true;
+    }
+    else
+      return false;
+  }
+  else
+    return false;
 }
 
 bool

--- a/framework/src/csg/CSGUniverseList.C
+++ b/framework/src/csg/CSGUniverseList.C
@@ -16,8 +16,9 @@ CSGUniverseList::CSGUniverseList()
 {
   // create root universe by default when CSG object is initialized
   std::string root_name = "ROOT_UNIVERSE";
-  _root_universe = std::make_shared<CSGUniverse>(root_name, /* is_root = */ true);
-  _universes.insert(std::make_pair(root_name, _root_universe));
+  auto root_universe = std::make_unique<CSGUniverse>(root_name, /* is_root = */ true);
+  _root_universe = root_universe.get();
+  _universes.insert(std::make_pair(root_name, std::move(root_universe)));
 }
 
 void
@@ -50,7 +51,7 @@ CSGUniverse &
 CSGUniverseList::addUniverse(const std::string name)
 {
   checkUniverseName(name);
-  _universes.insert(std::make_pair(name, std::make_shared<CSGUniverse>(name)));
+  _universes.insert(std::make_pair(name, std::make_unique<CSGUniverse>(name)));
   return *_universes[name];
 }
 
@@ -58,16 +59,16 @@ CSGUniverse &
 CSGUniverseList::addUniverse(const std::string name, std::vector<CSGCell *> & cells)
 {
   checkUniverseName(name);
-  _universes.insert(std::make_pair(name, std::make_shared<CSGUniverse>(name, cells)));
+  _universes.insert(std::make_pair(name, std::make_unique<CSGUniverse>(name, cells)));
   return *_universes[name];
 }
 
 void
-CSGUniverseList::addUniverse(std::shared_ptr<CSGUniverse> & universe)
+CSGUniverseList::addUniverse(std::unique_ptr<CSGUniverse> & universe)
 {
   auto name = universe->getName();
   checkUniverseName(name);
-  _universes.insert(std::make_pair(name, universe));
+  _universes.insert(std::make_pair(name, std::move(universe)));
 }
 
 void
@@ -76,7 +77,7 @@ CSGUniverseList::renameUniverse(CSGUniverse & universe, const std::string name)
   // check that this universe passed in is actually in the same universe that is in the universe
   // list
   auto prev_name = universe.getName();
-  auto existing_univ = _universes.find(prev_name)->second;
+  auto existing_univ = std::move(_universes.find(prev_name)->second);
   if (*existing_univ != universe)
     mooseError("Universe " + prev_name + " cannot be renamed to " + name +
                " as it does not exist in this CSGBase instance.");
@@ -84,7 +85,7 @@ CSGUniverseList::renameUniverse(CSGUniverse & universe, const std::string name)
   checkUniverseName(name);
   existing_univ->setName(name);
   _universes.erase(prev_name);
-  _universes.insert(std::make_pair(name, existing_univ));
+  _universes.insert(std::make_pair(name, std::move(existing_univ)));
 }
 
 } // namespace CSG

--- a/framework/src/csg/CSGUniverseList.C
+++ b/framework/src/csg/CSGUniverseList.C
@@ -72,7 +72,7 @@ CSGUniverseList::addUniverse(std::unique_ptr<CSGUniverse> & universe)
 }
 
 void
-CSGUniverseList::renameUniverse(CSGUniverse & universe, const std::string name)
+CSGUniverseList::renameUniverse(const CSGUniverse & universe, const std::string name)
 {
   // check that this universe passed in is actually in the same universe that is in the universe
   // list

--- a/framework/src/csg/CSGUniverseList.C
+++ b/framework/src/csg/CSGUniverseList.C
@@ -38,12 +38,12 @@ CSGUniverseList::getUniverse(const std::string name)
     return *(univ->second);
 }
 
-std::vector<CSGUniverse *>
+std::vector<std::reference_wrapper<const CSGUniverse>>
 CSGUniverseList::getAllUniverses() const
 {
-  std::vector<CSGUniverse *> univs;
+  std::vector<std::reference_wrapper<const CSGUniverse>> univs;
   for (auto it = _universes.begin(); it != _universes.end(); ++it)
-    univs.push_back(it->second.get());
+    univs.push_back(*(it->second.get()));
   return univs;
 }
 

--- a/test/src/csg/TestCSGAxialSurfaceMeshGenerator.C
+++ b/test/src/csg/TestCSGAxialSurfaceMeshGenerator.C
@@ -47,8 +47,8 @@ TestCSGAxialSurfaceMeshGenerator::generateCSG()
 
   auto root_univ = input_mesh->getRootUniverse();
   const auto cell_name = "square_cell";
-  auto cell_ptr = root_univ->getCell(cell_name);
-  auto cell_region = cell_ptr->getRegion();
+  auto & csg_cell = root_univ.getCell(cell_name);
+  auto cell_region = csg_cell.getRegion();
   const auto centroid = Point(0, 0, 0);
 
   // Add surfaces and halfspaces corresponding to top and bottom axial planes
@@ -65,7 +65,7 @@ TestCSGAxialSurfaceMeshGenerator::generateCSG()
     cell_region &= halfspace;
   }
 
-  input_mesh->updateCellRegion(cell_ptr, cell_region);
+  input_mesh->updateCellRegion(csg_cell, cell_region);
 
   return input_mesh;
 }

--- a/test/src/csg/TestCSGAxialSurfaceMeshGenerator.C
+++ b/test/src/csg/TestCSGAxialSurfaceMeshGenerator.C
@@ -58,10 +58,10 @@ TestCSGAxialSurfaceMeshGenerator::generateCSG()
   {
     const auto surf_name = "surf_" + surf_names[i];
     // z plane equation: 0.0*x + 0.0*y + 1.0*z = (+/-)0.5 * axial_height
-    auto plane_ptr = input_mesh->createPlaneFromCoefficients(surf_name, 0.0, 0.0, 1.0, coeffs[i]);
-    const auto region_direction = plane_ptr->directionFromPoint(centroid);
+    auto & csg_plane = input_mesh->createPlaneFromCoefficients(surf_name, 0.0, 0.0, 1.0, coeffs[i]);
+    const auto region_direction = csg_plane.directionFromPoint(centroid);
     auto halfspace =
-        ((region_direction == CSG::CSGSurface::Direction::POSITIVE) ? +plane_ptr : -plane_ptr);
+        ((region_direction == CSG::CSGSurface::Direction::POSITIVE) ? +csg_plane : -csg_plane);
     cell_region &= halfspace;
   }
 

--- a/test/src/csg/TestCSGCylindersMeshGenerator.C
+++ b/test/src/csg/TestCSGCylindersMeshGenerator.C
@@ -61,22 +61,22 @@ TestCSGCylindersMeshGenerator::generateCSG()
     b = 1;
   else if (_axis == "z")
     c = 1;
-  auto pos_plane = csg_mesh->createPlaneFromCoefficients(mg_name + "_pos_plane", a, b, c, _h / 2);
-  auto neg_plane =
+  auto & pos_plane = csg_mesh->createPlaneFromCoefficients(mg_name + "_pos_plane", a, b, c, _h / 2);
+  auto & neg_plane =
       csg_mesh->createPlaneFromCoefficients(mg_name + "_neg_plane", a, b, c, -1 * _h / 2);
 
   std::string prev_surf_name;
   for (unsigned int i = 0; i < _radii.size(); ++i)
   {
     std::string surf_name = mg_name + "_surf_cyl_" + _axis + "_" + std::to_string(i);
-    auto cyl_surf = csg_mesh->createCylinder(surf_name, _x0, _x1, _radii[i], _axis);
+    auto & cyl_surf = csg_mesh->createCylinder(surf_name, _x0, _x1, _radii[i], _axis);
     CSG::CSGRegion region;
     std::string cell_name = mg_name + "_cell_cyl_" + _axis + "_" + std::to_string(i);
     if (i == 0)
       region = -cyl_surf & -pos_plane & +neg_plane;
     else
     {
-      auto prev_surf = csg_mesh->getSurfaceByName(prev_surf_name);
+      auto & prev_surf = csg_mesh->getSurfaceByName(prev_surf_name);
       region = +prev_surf & -cyl_surf & -pos_plane & +neg_plane;
     }
     auto cell = csg_mesh->createCell(cell_name, region);

--- a/test/src/csg/TestCSGCylindersMeshGenerator.C
+++ b/test/src/csg/TestCSGCylindersMeshGenerator.C
@@ -76,7 +76,7 @@ TestCSGCylindersMeshGenerator::generateCSG()
       region = -cyl_surf & -pos_plane & +neg_plane;
     else
     {
-      auto & prev_surf = csg_mesh->getSurfaceByName(prev_surf_name);
+      const auto & prev_surf = csg_mesh->getSurfaceByName(prev_surf_name);
       region = +prev_surf & -cyl_surf & -pos_plane & +neg_plane;
     }
     auto cell = csg_mesh->createCell(cell_name, region);

--- a/test/src/csg/TestCSGInfiniteSquareMeshGenerator.C
+++ b/test/src/csg/TestCSGInfiniteSquareMeshGenerator.C
@@ -79,10 +79,10 @@ TestCSGInfiniteSquareMeshGenerator::generateCSG()
   const auto cell_name = "square_cell";
   const auto material_name = "square_material";
 
-  auto cell_ptr = csg_mesh->createCell(cell_name, material_name, region);
+  auto & csg_cell = csg_mesh->createCell(cell_name, material_name, region);
 
   // set all surface boundary conditions to reflective
-  auto all_surfs = cell_ptr->getRegion().getSurfaces();
+  auto all_surfs = csg_cell.getRegion().getSurfaces();
   for (auto s : all_surfs)
   {
     csg_mesh->updateSurfaceBoundaryType(*s, CSG::CSGSurface::BoundaryType::REFLECTIVE);

--- a/test/src/csg/TestCSGInfiniteSquareMeshGenerator.C
+++ b/test/src/csg/TestCSGInfiniteSquareMeshGenerator.C
@@ -82,9 +82,9 @@ TestCSGInfiniteSquareMeshGenerator::generateCSG()
   auto & csg_cell = csg_mesh->createCell(cell_name, material_name, region);
 
   // set all surface boundary conditions to reflective
-  auto all_surfs = csg_cell.getRegion().getSurfaces();
-  for (auto s : all_surfs)
-    csg_mesh->updateSurfaceBoundaryType(*s, CSG::CSGSurface::BoundaryType::REFLECTIVE);
+  auto & all_surfs = csg_cell.getRegion().getSurfaces();
+  for (auto & s : all_surfs)
+    csg_mesh->updateSurfaceBoundaryType(s, CSG::CSGSurface::BoundaryType::REFLECTIVE);
 
   return csg_mesh;
 }

--- a/test/src/csg/TestCSGInfiniteSquareMeshGenerator.C
+++ b/test/src/csg/TestCSGInfiniteSquareMeshGenerator.C
@@ -64,11 +64,11 @@ TestCSGInfiniteSquareMeshGenerator::generateCSG()
   for (unsigned int i = 0; i < points_on_planes.size(); ++i)
   {
     const auto surf_name = "surf_" + surf_names[i];
-    auto plane_ptr = csg_mesh->createPlaneFromPoints(
+    auto & csg_plane = csg_mesh->createPlaneFromPoints(
         surf_name, points_on_planes[i][0], points_on_planes[i][1], points_on_planes[i][2]);
-    const auto region_direction = plane_ptr->directionFromPoint(centroid);
+    const auto region_direction = csg_plane.directionFromPoint(centroid);
     auto halfspace =
-        ((region_direction == CSG::CSGSurface::Direction::POSITIVE) ? +plane_ptr : -plane_ptr);
+        ((region_direction == CSG::CSGSurface::Direction::POSITIVE) ? +csg_plane : -csg_plane);
     // check if first halfspace to be added to the region
     if (region.getRegionType() == CSG::CSGRegion::RegionType::EMPTY)
       region = halfspace;
@@ -85,7 +85,7 @@ TestCSGInfiniteSquareMeshGenerator::generateCSG()
   auto all_surfs = cell_ptr->getRegion().getSurfaces();
   for (auto s : all_surfs)
   {
-    csg_mesh->updateSurfaceBoundaryType(s, CSG::CSGSurface::BoundaryType::REFLECTIVE);
+    csg_mesh->updateSurfaceBoundaryType(*s, CSG::CSGSurface::BoundaryType::REFLECTIVE);
   }
 
   return csg_mesh;

--- a/test/src/csg/TestCSGInfiniteSquareMeshGenerator.C
+++ b/test/src/csg/TestCSGInfiniteSquareMeshGenerator.C
@@ -84,9 +84,7 @@ TestCSGInfiniteSquareMeshGenerator::generateCSG()
   // set all surface boundary conditions to reflective
   auto all_surfs = csg_cell.getRegion().getSurfaces();
   for (auto s : all_surfs)
-  {
     csg_mesh->updateSurfaceBoundaryType(*s, CSG::CSGSurface::BoundaryType::REFLECTIVE);
-  }
 
   return csg_mesh;
 }

--- a/test/src/csg/TestCSGRegionSurfaceError.C
+++ b/test/src/csg/TestCSGRegionSurfaceError.C
@@ -52,7 +52,7 @@ TestCSGRegionSurfaceError::generateCSG()
   // try to apply the region from cell_1 to cell_2
   // This will produce an error that the surfaces of the region are not the
   // same surfaces in memory, despite having the same name
-  auto reg_1 = cell_1->getRegion();
+  auto & reg_1 = cell_1.getRegion();
   csg_2->updateCellRegion(cell_2, reg_1);
 
   return csg_1;

--- a/test/src/csg/TestCSGRegionTypesMeshGenerator.C
+++ b/test/src/csg/TestCSGRegionTypesMeshGenerator.C
@@ -55,10 +55,10 @@ TestCSGRegionTypesMeshGenerator::generateCSG()
   {
     const auto surf_name = "surf_" + surf_names[i];
     const auto plane_coeff = plane_coeffs[i];
-    auto plane_ptr = csg_mesh->createPlaneFromCoefficients(
+    auto & csg_plane = csg_mesh->createPlaneFromCoefficients(
         surf_name, plane_coeff[0], plane_coeff[1], plane_coeff[2], plane_coeff[3]);
-    auto pos_halfspace = +plane_ptr;
-    auto neg_halfspace = -plane_ptr;
+    auto pos_halfspace = +csg_plane;
+    auto neg_halfspace = -csg_plane;
     if (surf_names[i] == "plus_x")
       region_right = neg_halfspace;
     else if (surf_names[i] == "minus_x")

--- a/test/src/csg/TestCSGRenameError.C
+++ b/test/src/csg/TestCSGRenameError.C
@@ -54,7 +54,7 @@ TestCSGRenameError::generateCSG()
   if (_mode == "surface")
   {
     // get surface from base 1 of the same name to try to rename in base 2
-    auto & surf_1 = csg_1->getSurfaceByName("surf_plus_x");
+    const auto & surf_1 = csg_1->getSurfaceByName("surf_plus_x");
     // should produce error that surface is not the same in memory despite having the same name
     csg_2->renameSurface(surf_1, "test_new_surf_name");
   }

--- a/test/src/csg/TestCSGRenameError.C
+++ b/test/src/csg/TestCSGRenameError.C
@@ -61,7 +61,7 @@ TestCSGRenameError::generateCSG()
   if (_mode == "cell")
   {
     // get cell from base 1 of the same name to try to rename in base 2
-    auto cell_1 = csg_1->getCellByName("square_cell");
+    auto & cell_1 = csg_1->getCellByName("square_cell");
     // should produce error that cell is not the same in memory despite having the same name
     csg_2->renameCell(cell_1, "test_new_cell_name");
   }

--- a/test/src/csg/TestCSGRenameError.C
+++ b/test/src/csg/TestCSGRenameError.C
@@ -54,7 +54,7 @@ TestCSGRenameError::generateCSG()
   if (_mode == "surface")
   {
     // get surface from base 1 of the same name to try to rename in base 2
-    auto surf_1 = csg_1->getSurfaceByName("surf_plus_x");
+    auto & surf_1 = csg_1->getSurfaceByName("surf_plus_x");
     // should produce error that surface is not the same in memory despite having the same name
     csg_2->renameSurface(surf_1, "test_new_surf_name");
   }

--- a/test/src/csg/TestCSGSphereAtOriginMeshGenerator.C
+++ b/test/src/csg/TestCSGSphereAtOriginMeshGenerator.C
@@ -43,7 +43,7 @@ TestCSGSphereAtOriginMeshGenerator::generateCSG()
   auto csg_mesh = std::make_unique<CSG::CSGBase>();
   auto mg_name = this->name();
 
-  auto sphere_surf = csg_mesh->createSphere(mg_name + "_sphere_surf", _radius);
+  auto & sphere_surf = csg_mesh->createSphere(mg_name + "_sphere_surf", _radius);
   auto sphere_cell = csg_mesh->createCell(mg_name + "_sphere_cell", -sphere_surf);
 
   return csg_mesh;

--- a/test/src/csg/TestCSGSphereAtPointMeshGenerator.C
+++ b/test/src/csg/TestCSGSphereAtPointMeshGenerator.C
@@ -43,8 +43,9 @@ TestCSGSphereAtPointMeshGenerator::generateCSG()
   auto csg_mesh = std::make_unique<CSG::CSGBase>();
   auto mg_name = this->name();
 
-  auto sphere_surf = csg_mesh->createSphere(mg_name + "_sphere_surf", _center, _radius);
-  auto sphere_cell = csg_mesh->createCell(mg_name + "_sphere_cell", "new_mat", -sphere_surf);
+  auto & sphere_surf = csg_mesh->createSphere(mg_name + "_sphere_surf", _center, _radius);
+  const auto & sphere_cell =
+      csg_mesh->createCell(mg_name + "_sphere_cell", "new_mat", -sphere_surf);
 
   return csg_mesh;
 }

--- a/test/src/csg/TestCSGSphereAtPointMeshGenerator.C
+++ b/test/src/csg/TestCSGSphereAtPointMeshGenerator.C
@@ -44,8 +44,7 @@ TestCSGSphereAtPointMeshGenerator::generateCSG()
   auto mg_name = this->name();
 
   auto & sphere_surf = csg_mesh->createSphere(mg_name + "_sphere_surf", _center, _radius);
-  const auto & sphere_cell =
-      csg_mesh->createCell(mg_name + "_sphere_cell", "new_mat", -sphere_surf);
+  csg_mesh->createCell(mg_name + "_sphere_cell", "new_mat", -sphere_surf);
 
   return csg_mesh;
 }

--- a/test/src/csg/TestCSGUniverseMeshGenerator.C
+++ b/test/src/csg/TestCSGUniverseMeshGenerator.C
@@ -72,7 +72,7 @@ TestCSGUniverseMeshGenerator::generateCSG()
   // new universe to collect all others into a main one
   auto & new_univ = csg_mesh->createUniverse(mg_name + "_univ");
   // collect a list of cells to add to this new universe
-  std::vector<CSG::CSGCell *> cells_to_add;
+  std::vector<const CSG::CSGCell *> cells_to_add;
 
   // for all input meshes, create a containment cell, but only join CSGBases
   // for ones that were not joined above (i > 1)

--- a/test/src/csg/TestCSGUniverseMeshGenerator.C
+++ b/test/src/csg/TestCSGUniverseMeshGenerator.C
@@ -121,17 +121,17 @@ TestCSGUniverseMeshGenerator::generateCSG()
     }
 
     // bounding box for new cell - located at the origin
-    auto x_pos_surf = csg_mesh->createPlaneFromCoefficients(
+    auto & x_pos_surf = csg_mesh->createPlaneFromCoefficients(
         img + "_x_pos_surf", 1.0, 0, 0, x + 0.5 * side_lengths[i]);
-    auto x_neg_surf = csg_mesh->createPlaneFromCoefficients(
+    auto & x_neg_surf = csg_mesh->createPlaneFromCoefficients(
         img + "_x_neg_surf", 1.0, 0, 0, x - 0.5 * side_lengths[i]);
-    auto y_pos_surf = csg_mesh->createPlaneFromCoefficients(
+    auto & y_pos_surf = csg_mesh->createPlaneFromCoefficients(
         img + "_y_pos_surf", 0, 1.0, 0, y + 0.5 * side_lengths[i]);
-    auto y_neg_surf = csg_mesh->createPlaneFromCoefficients(
+    auto & y_neg_surf = csg_mesh->createPlaneFromCoefficients(
         img + "_y_neg_surf", 0, 1.0, 0, y - 0.5 * side_lengths[i]);
-    auto z_pos_surf = csg_mesh->createPlaneFromCoefficients(
+    auto & z_pos_surf = csg_mesh->createPlaneFromCoefficients(
         img + "_z_pos_surf", 0, 0, 1.0, z + 0.5 * side_lengths[i]);
-    auto z_neg_surf = csg_mesh->createPlaneFromCoefficients(
+    auto & z_neg_surf = csg_mesh->createPlaneFromCoefficients(
         img + "_z_neg_surf", 0, 0, 1.0, z - 0.5 * side_lengths[i]);
     auto new_region =
         -x_pos_surf & +x_neg_surf & -y_pos_surf & +y_neg_surf & -z_pos_surf & +z_neg_surf;
@@ -159,17 +159,17 @@ TestCSGUniverseMeshGenerator::generateCSG()
   // make cell with surfaces from bounding_box input and fill cell with new universe containing the
   // other cells
   auto bc_vac = CSG::CSGSurface::BoundaryType::VACUUM; // vacuum bc for bounding box
-  auto x_pos_surf = csg_mesh->createPlaneFromCoefficients(
+  auto & x_pos_surf = csg_mesh->createPlaneFromCoefficients(
       mg_name + "_bb_x_pos_surf", 1.0, 0, 0, 0.5 * _x_side, bc_vac);
-  auto x_neg_surf = csg_mesh->createPlaneFromCoefficients(
+  auto & x_neg_surf = csg_mesh->createPlaneFromCoefficients(
       mg_name + "_bb_x_neg_surf", 1.0, 0, 0, -0.5 * _x_side, bc_vac);
-  auto y_pos_surf = csg_mesh->createPlaneFromCoefficients(
+  auto & y_pos_surf = csg_mesh->createPlaneFromCoefficients(
       mg_name + "_bb_y_pos_surf", 0, 1.0, 0, 0.5 * _y_side, bc_vac);
-  auto y_neg_surf = csg_mesh->createPlaneFromCoefficients(
+  auto & y_neg_surf = csg_mesh->createPlaneFromCoefficients(
       mg_name + "_bb_y_neg_surf", 0, 1.0, 0, -0.5 * _y_side, bc_vac);
-  auto z_pos_surf = csg_mesh->createPlaneFromCoefficients(
+  auto & z_pos_surf = csg_mesh->createPlaneFromCoefficients(
       mg_name + "_bb_z_pos_surf", 0, 0, 1.0, 0.5 * _z_side, bc_vac);
-  auto z_neg_surf = csg_mesh->createPlaneFromCoefficients(
+  auto & z_neg_surf = csg_mesh->createPlaneFromCoefficients(
       mg_name + "_bb_z_neg_surf", 0, 0, 1.0, -0.5 * _z_side, bc_vac);
   auto bb_region =
       -x_pos_surf & +x_neg_surf & -y_pos_surf & +y_neg_surf & -z_pos_surf & +z_neg_surf;

--- a/test/src/csg/TestCSGUniverseMeshGenerator.C
+++ b/test/src/csg/TestCSGUniverseMeshGenerator.C
@@ -70,9 +70,9 @@ TestCSGUniverseMeshGenerator::generateCSG()
   csg_mesh->joinOtherBase(inp_csg_mesh, new_base_name, new_join_name);
 
   // new universe to collect all others into a main one
-  auto new_univ = csg_mesh->createUniverse(mg_name + "_univ");
+  auto & new_univ = csg_mesh->createUniverse(mg_name + "_univ");
   // collect a list of cells to add to this new universe
-  std::vector<std::shared_ptr<CSG::CSGCell>> cells_to_add;
+  std::vector<CSG::CSGCell *> cells_to_add;
 
   // for all input meshes, create a containment cell, but only join CSGBases
   // for ones that were not joined above (i > 1)
@@ -97,7 +97,7 @@ TestCSGUniverseMeshGenerator::generateCSG()
 
     // create a cell containing the new (root) univ
     // cell is located at the origin of the original cells - just use one cell to get origin
-    auto inp_cells = csg_mesh->getUniverseByName(current_univ_name)->getAllCells();
+    auto inp_cells = csg_mesh->getUniverseByName(current_univ_name).getAllCells();
     auto tmp_cell = inp_cells[0];
     auto tmp_cell_reg = tmp_cell->getRegion();
     auto cell_surfs = tmp_cell_reg.getSurfaces();
@@ -137,16 +137,16 @@ TestCSGUniverseMeshGenerator::generateCSG()
         -x_pos_surf & +x_neg_surf & -y_pos_surf & +y_neg_surf & -z_pos_surf & +z_neg_surf;
 
     // create a cell and add it to the new universe
-    auto univ_ptr = csg_mesh->getUniverseByName(current_univ_name);
+    auto & csg_univ = csg_mesh->getUniverseByName(current_univ_name);
     std::string new_cell_name = img + "_cell";
     if (_add_cell_mode)
     {
       // don't add to the new universe right away, do so later with the addCellsToUniverse method
-      auto img_cell = csg_mesh->createCell(new_cell_name, univ_ptr, new_region);
-      cells_to_add.push_back(img_cell);
+      auto & img_cell = csg_mesh->createCell(new_cell_name, csg_univ, new_region);
+      cells_to_add.push_back(&img_cell);
     }
     else // add to the new universe at time of creation
-      auto img_cell = csg_mesh->createCell(new_cell_name, univ_ptr, new_region, new_univ);
+      csg_mesh->createCell(new_cell_name, csg_univ, new_region, &new_univ);
   }
 
   if (_add_cell_mode)

--- a/test/src/csg/TestCSGUniverseMeshGenerator.C
+++ b/test/src/csg/TestCSGUniverseMeshGenerator.C
@@ -72,7 +72,7 @@ TestCSGUniverseMeshGenerator::generateCSG()
   // new universe to collect all others into a main one
   auto & new_univ = csg_mesh->createUniverse(mg_name + "_univ");
   // collect a list of cells to add to this new universe
-  std::vector<const CSG::CSGCell *> cells_to_add;
+  std::vector<std::reference_wrapper<const CSG::CSGCell>> cells_to_add;
 
   // for all input meshes, create a containment cell, but only join CSGBases
   // for ones that were not joined above (i > 1)
@@ -97,19 +97,19 @@ TestCSGUniverseMeshGenerator::generateCSG()
 
     // create a cell containing the new (root) univ
     // cell is located at the origin of the original cells - just use one cell to get origin
-    auto inp_cells = csg_mesh->getUniverseByName(current_univ_name).getAllCells();
-    auto tmp_cell = inp_cells[0];
-    auto tmp_cell_reg = tmp_cell->getRegion();
-    auto cell_surfs = tmp_cell_reg.getSurfaces();
+    auto & inp_cells = csg_mesh->getUniverseByName(current_univ_name).getAllCells();
+    const CSG::CSGCell & tmp_cell = inp_cells[0];
+    auto & tmp_cell_reg = tmp_cell.getRegion();
+    auto & cell_surfs = tmp_cell_reg.getSurfaces();
     Real x = 0, y = 0, z = 0;
-    for (auto cs : cell_surfs)
+    for (const CSG::CSGSurface & cs : cell_surfs)
     {
       // find first non-plane surf to get the origin
-      if (cs->getSurfaceType() == CSG::CSGSurface::SurfaceType::PLANE)
+      if (cs.getSurfaceType() == CSG::CSGSurface::SurfaceType::PLANE)
         continue;
       else
       {
-        auto coeffs = cs->getCoeffs();
+        auto coeffs = cs.getCoeffs();
         if (coeffs.find("x0") != coeffs.end())
           x = coeffs.at("x0");
         if (coeffs.find("y0") != coeffs.end())
@@ -142,8 +142,8 @@ TestCSGUniverseMeshGenerator::generateCSG()
     if (_add_cell_mode)
     {
       // don't add to the new universe right away, do so later with the addCellsToUniverse method
-      auto & img_cell = csg_mesh->createCell(new_cell_name, csg_univ, new_region);
-      cells_to_add.push_back(&img_cell);
+      const auto & img_cell = csg_mesh->createCell(new_cell_name, csg_univ, new_region);
+      cells_to_add.push_back(img_cell);
     }
     else // add to the new universe at time of creation
       csg_mesh->createCell(new_cell_name, csg_univ, new_region, &new_univ);


### PR DESCRIPTION
<!--
If this PR is associated with an issue be sure to reference it
by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).

If this PR implements an enhancement that does not have an existing issue, please add the following:
-->

This is still WIP, just wanted to push up the changes I have so far so that you have an idea of what to expect in terms of changes to the branch to address comments raised by Guillaume and Logan

A few notes:
- Ideally I would have liked to return reference to CSGSurface as a const reference instead of non-const. However, some attributes such as name and boundary type can be changed later on so need to return non-const reference to CSGSurface in case these attributes need to be modified later on
- Since we are passing references to the object instead of pointers to the object now, we need to update the code in places to test for equality of references instead of equality of pointers. In order to support this, I needed to overload the `==` and `!=` operators for the CSGSurface objects explicitly to support this, instead of simply making sure that the pointers point to the same memory locations.
- Tests still pass locally with these changes

Remaining work:
- [x] Change std::shared_ptr to std::unique_ptr wherever it makes sense
- [x] Extend changes to use references to CSGCell and CSGUniverse instead of shared_ptr wherever it makes sense
- [x] Update documentation and docstrings wherever necessary