### PR TITLE
Throw an error if point used to determine halfspace lies on surface

### DIFF
--- a/framework/doc/content/source/csg/CSGBase.md
+++ b/framework/doc/content/source/csg/CSGBase.md
@@ -61,6 +61,12 @@ std::unique_ptr<CSG::CSGSurface> surf_ptr = std::make_unique<SurfaceType>(argume
 const auto & surface = csg_obj->addSurface(surf_ptr);
 ```
 
+!alert! note title=Adding surfaces to the CSGBase instance
+
+Surfaces need to be added to the CSGBase instance with `addSurace` as described above. If this is not done and these surfaces are referenced in regions used to define cells within the CSGBase instance, an error will occur.
+
+!alert-end!
+
 The `CSG` framework in MOOSE provides various classes for creating basic surfaces (see table below).
 Information about how to define new types of surfaces can be found in [source/csg/CSGSurface.md].
 

--- a/framework/doc/content/source/csg/CSGSurface.md
+++ b/framework/doc/content/source/csg/CSGSurface.md
@@ -20,7 +20,7 @@ For example, a plane is defined by the equation $ax + by + cz = d$ and so this m
 ### Half-space Determination
 
 In [!ac](CSG) representation, knowing which half-space of the surface is positive or negative is necessary for correct construction of a [cell](source/csg/CSGBase.md#cells) [region](source/csg/CSGBase.md#regions).
-To help determine the sign of these half-spaces, each surface type should have a `getHalfspaceFromPoint` method implemented that can be used to determine if a point lies within the positive (`CSGSurface::Halfspace::POSITIVE`) or negative (`CSGSurface::Halfspace::NEGATIVE`) half-space for the surface.
+To help determine the sign of these half-spaces, each surface type should have a `evaluateSurfaceEquationAtPoint` method implemented that returns a floating point value, where a positive value indicates that the point lies in the positive halfspace, a negative value indicates that the point lies in the negative halfspace, and a value of 0 indicates that the point lies on the surface.
 
 ### Setting the Surface Type
 

--- a/framework/include/csg/CSGPlane.h
+++ b/framework/include/csg/CSGPlane.h
@@ -70,13 +70,12 @@ public:
   virtual std::unordered_map<std::string, Real> getCoeffs() const override;
 
   /**
-   * @brief given a point, determine if it is in the positive or negative
-   * half-space of the plane as compared to the surface normal
+   * @brief given a point, determine its evaluation based on the equation of the plane
    *
    * @param p point
-   * @return sign of the half-space
+   * @return evaluation of point based on surface equation
    */
-  virtual CSGSurface::Halfspace getHalfspaceFromPoint(const Point & p) const override;
+  virtual Real evaluateSurfaceEquationAtPoint(const Point & p) const override;
 
 protected:
   // calculate the equivalent coeffients (aX + bY + cZ = d) from 3 points on a plane

--- a/framework/include/csg/CSGSphere.h
+++ b/framework/include/csg/CSGSphere.h
@@ -60,13 +60,12 @@ public:
   virtual std::unordered_map<std::string, Real> getCoeffs() const override;
 
   /**
-   * @brief given a point, determine if it is in the positive (outside) or negative
-   * (inside) half-space for the sphere
+   * @brief given a point, determine its evaluation based on the equation of the sphere
    *
    * @param p point
-   * @return sign of the half-space
+   * @return evaluation of point based on surface equation
    */
-  virtual CSGSurface::Halfspace getHalfspaceFromPoint(const Point & p) const override;
+  virtual Real evaluateSurfaceEquationAtPoint(const Point & p) const override;
 
 protected:
   // check that radius is positive

--- a/framework/include/csg/CSGSurface.h
+++ b/framework/include/csg/CSGSurface.h
@@ -79,14 +79,24 @@ public:
   virtual std::unordered_map<std::string, Real> getCoeffs() const = 0; // Pure virtual function
 
   /**
+   * @brief given a point, determine its evaluation based on the surface equation. A positive value
+   * indicates a point that lies in the positive value of the surface, a negative value
+   * indicates a point that lies in the negative value of the surface, and a value of 0 indicates
+   * that the point lies on the surface.
+   *
+   * @param p point
+   * @return evaluation of point based on surface equation
+   */
+  virtual Real evaluateSurfaceEquationAtPoint(const Point & p) const = 0; // Pure virtual function
+
+  /**
    * @brief given a point, determine if it is in the positive or negative
    * half-space for the surface
    *
    * @param p point
    * @return sign of the half-space
    */
-  virtual CSGSurface::Halfspace
-  getHalfspaceFromPoint(const Point & p) const = 0; // Pure virtual function
+  CSGSurface::Halfspace getHalfspaceFromPoint(const Point & p) const;
 
   /**
    * @brief Get the name of surface

--- a/framework/include/csg/CSGXCylinder.h
+++ b/framework/include/csg/CSGXCylinder.h
@@ -52,13 +52,12 @@ public:
   virtual std::unordered_map<std::string, Real> getCoeffs() const override;
 
   /**
-   * @brief given a point, determine if it is in the positive (outside) or negative
-   * (inside) half-space for the cylinder
+   * @brief given a point, determine its evaluation based on the equation of the cylinder
    *
    * @param p point
-   * @return sign of the half-space
+   * @return evaluation of point based on surface equation
    */
-  virtual CSGSurface::Halfspace getHalfspaceFromPoint(const Point & p) const override;
+  virtual Real evaluateSurfaceEquationAtPoint(const Point & p) const override;
 
 protected:
   /// Value of y0 in equation of an x-axis aligned cylinder

--- a/framework/include/csg/CSGYCylinder.h
+++ b/framework/include/csg/CSGYCylinder.h
@@ -52,13 +52,12 @@ public:
   virtual std::unordered_map<std::string, Real> getCoeffs() const override;
 
   /**
-   * @brief given a point, determine if it is in the positive (outside) or negative
-   * (inside) half-space for the cylinder
+   * @brief given a point, determine its evaluation based on the equation of the cylinder
    *
    * @param p point
-   * @return sign of the half-space
+   * @return evaluation of point based on surface equation
    */
-  virtual CSGSurface::Halfspace getHalfspaceFromPoint(const Point & p) const override;
+  virtual Real evaluateSurfaceEquationAtPoint(const Point & p) const override;
 
 protected:
   /// Value of x0 in equation of an y-axis aligned cylinder

--- a/framework/include/csg/CSGZCylinder.h
+++ b/framework/include/csg/CSGZCylinder.h
@@ -52,13 +52,12 @@ public:
   virtual std::unordered_map<std::string, Real> getCoeffs() const override;
 
   /**
-   * @brief given a point, determine if it is in the positive (outside) or negative
-   * (inside) half-space for the cylinder
+   * @brief given a point, determine its evaluation based on the equation of the cylinder
    *
    * @param p point
-   * @return sign of the half-space
+   * @return evaluation of point based on surface equation
    */
-  virtual CSGSurface::Halfspace getHalfspaceFromPoint(const Point & p) const override;
+  virtual Real evaluateSurfaceEquationAtPoint(const Point & p) const override;
 
 protected:
   /// Value of x0 in equation of an z-axis aligned cylinder

--- a/framework/src/csg/CSGPlane.C
+++ b/framework/src/csg/CSGPlane.C
@@ -58,14 +58,13 @@ CSGPlane::coeffsFromPoints(const Point & p1, const Point & p2, const Point & p3)
   _d = cross * (RealVectorValue)p1;
 }
 
-CSGSurface::Halfspace
-CSGPlane::getHalfspaceFromPoint(const Point & p) const
+Real
+CSGPlane::evaluateSurfaceEquationAtPoint(const Point & p) const
 {
   // Compute dot product of <a, b, c> and p to determine if p lies
   // in the positive or negative halfspace of the plane
   const Real dot_prod = _a * p(0) + _b * p(1) + _c * p(2);
 
-  // TODO add MooseAssert that point doesn't lie on plane
-  return (dot_prod > _d) ? CSGSurface::Halfspace::POSITIVE : CSGSurface::Halfspace::NEGATIVE;
+  return dot_prod - _d;
 }
 } // namespace CSG

--- a/framework/src/csg/CSGSphere.C
+++ b/framework/src/csg/CSGSphere.C
@@ -42,15 +42,14 @@ CSGSphere::getCoeffs() const
   return coeffs;
 }
 
-CSGSurface::Halfspace
-CSGSphere::getHalfspaceFromPoint(const Point & p) const
+Real
+CSGSphere::evaluateSurfaceEquationAtPoint(const Point & p) const
 {
   // Compute distance from the sphere center to determine if inside (< r^2)
   // or outside (> r^2) the sphere
   const Real dist_sq =
       Utility::pow<2>((p(0) - _x0)) + Utility::pow<2>((p(1) - _y0)) + Utility::pow<2>((p(2) - _z0));
 
-  return (dist_sq > Utility::pow<2>(_r)) ? CSGSurface::Halfspace::POSITIVE
-                                         : CSGSurface::Halfspace::NEGATIVE;
+  return dist_sq - Utility::pow<2>(_r);
 }
 } // namespace CSG

--- a/framework/src/csg/CSGSurface.C
+++ b/framework/src/csg/CSGSurface.C
@@ -21,6 +21,22 @@ CSGSurface::CSGSurface(const std::string & name,
 {
 }
 
+CSGSurface::Halfspace
+CSGSurface::getHalfspaceFromPoint(const Point & p) const
+{
+  auto eval = evaluateSurfaceEquationAtPoint(p);
+  if (MooseUtils::absoluteFuzzyGreaterThan(eval, 0))
+    return Halfspace::POSITIVE;
+  else if (MooseUtils::absoluteFuzzyLessThan(eval, 0))
+    return Halfspace::NEGATIVE;
+  else
+    mooseError("Point ",
+               p,
+               " used to determine halfspace evaluation lies on the surface ",
+               _name,
+               ", leading to an ambiguously defined halfspace.");
+}
+
 bool
 CSGSurface::operator==(const CSGSurface & other) const
 {

--- a/framework/src/csg/CSGXCylinder.C
+++ b/framework/src/csg/CSGXCylinder.C
@@ -25,14 +25,13 @@ CSGXCylinder::getCoeffs() const
   return coeffs;
 }
 
-CSGSurface::Halfspace
-CSGXCylinder::getHalfspaceFromPoint(const Point & p) const
+Real
+CSGXCylinder::evaluateSurfaceEquationAtPoint(const Point & p) const
 {
   // Compute distance from the cylinder center to determine if inside (< r^2)
   // or outside (> r^2) the cylinder
   const Real dist_sq = Utility::pow<2>((p(1) - _y0)) + Utility::pow<2>((p(2) - _z0));
 
-  return (dist_sq > Utility::pow<2>(_r)) ? CSGSurface::Halfspace::POSITIVE
-                                         : CSGSurface::Halfspace::NEGATIVE;
+  return dist_sq - Utility::pow<2>(_r);
 }
 } // namespace CSG

--- a/framework/src/csg/CSGYCylinder.C
+++ b/framework/src/csg/CSGYCylinder.C
@@ -25,14 +25,13 @@ CSGYCylinder::getCoeffs() const
   return coeffs;
 }
 
-CSGSurface::Halfspace
-CSGYCylinder::getHalfspaceFromPoint(const Point & p) const
+Real
+CSGYCylinder::evaluateSurfaceEquationAtPoint(const Point & p) const
 {
   // Compute distance from the cylinder center to determine if inside (< r^2)
   // or outside (> r^2) the cylinder
   const Real dist_sq = Utility::pow<2>((p(0) - _x0)) + Utility::pow<2>((p(2) - _z0));
 
-  return (dist_sq > Utility::pow<2>(_r)) ? CSGSurface::Halfspace::POSITIVE
-                                         : CSGSurface::Halfspace::NEGATIVE;
+  return dist_sq - Utility::pow<2>(_r);
 }
 } // namespace CSG

--- a/framework/src/csg/CSGZCylinder.C
+++ b/framework/src/csg/CSGZCylinder.C
@@ -25,14 +25,13 @@ CSGZCylinder::getCoeffs() const
   return coeffs;
 }
 
-CSGSurface::Halfspace
-CSGZCylinder::getHalfspaceFromPoint(const Point & p) const
+Real
+CSGZCylinder::evaluateSurfaceEquationAtPoint(const Point & p) const
 {
   // Compute distance from the cylinder center to determine if inside (< r^2)
   // or outside (> r^2) the cylinder
   const Real dist_sq = Utility::pow<2>((p(0) - _x0)) + Utility::pow<2>((p(1) - _y0));
 
-  return (dist_sq > Utility::pow<2>(_r)) ? CSGSurface::Halfspace::POSITIVE
-                                         : CSGSurface::Halfspace::NEGATIVE;
+  return dist_sq - Utility::pow<2>(_r);
 }
 } // namespace CSG

--- a/test/include/csg/TestCSGAmbiguousHalfspaceError.h
+++ b/test/include/csg/TestCSGAmbiguousHalfspaceError.h
@@ -1,0 +1,30 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "MeshGenerator.h"
+
+class TestCSGAmbiguousHalfspaceError : public MeshGenerator
+{
+public:
+  static InputParameters validParams();
+
+  TestCSGAmbiguousHalfspaceError(const InputParameters & parameters);
+
+  std::unique_ptr<MeshBase> generate() override;
+
+  void generateData() override {};
+
+  std::unique_ptr<CSG::CSGBase> generateCSG() override;
+
+protected:
+  /// the side length of the infinite square
+  const Real _side_length;
+};

--- a/test/src/csg/TestCSGAmbiguousHalfspaceError.C
+++ b/test/src/csg/TestCSGAmbiguousHalfspaceError.C
@@ -1,0 +1,61 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "TestCSGAmbiguousHalfspaceError.h"
+#include "CSGBase.h"
+#include "CSGPlane.h"
+
+registerMooseObject("MooseTestApp", TestCSGAmbiguousHalfspaceError);
+
+InputParameters
+TestCSGAmbiguousHalfspaceError::validParams()
+{
+  InputParameters params = MeshGenerator::validParams();
+
+  params.addRequiredParam<Real>("side_length", "Side length of infinite square.");
+  // Declare that this generator has a generateData method
+  MeshGenerator::setHasGenerateData(params);
+  // Declare that this generator has a generateCSG method
+  MeshGenerator::setHasGenerateCSG(params);
+  return params;
+}
+
+TestCSGAmbiguousHalfspaceError::TestCSGAmbiguousHalfspaceError(const InputParameters & params)
+  : MeshGenerator(params), _side_length(getParam<Real>("side_length"))
+{
+}
+
+std::unique_ptr<MeshBase>
+TestCSGAmbiguousHalfspaceError::generate()
+{
+  auto null_mesh = nullptr;
+  return null_mesh;
+}
+
+std::unique_ptr<CSG::CSGBase>
+TestCSGAmbiguousHalfspaceError::generateCSG()
+{
+  auto csg_obj = std::make_unique<CSG::CSGBase>();
+
+  // Add surfaces and halfspaces corresponding to 4 planes of infinite square
+  std::vector<Point> points_on_plane{Point(1. * _side_length / 2., 0., 0.),
+                                     Point(1. * _side_length / 2., 1., 0.),
+                                     Point(1. * _side_length / 2., 0., 1.)};
+
+  CSG::CSGRegion region;
+  const auto surf_name = "surf_plus_x";
+  std::unique_ptr<CSG::CSGSurface> plane_ptr = std::make_unique<CSG::CSGPlane>(
+      surf_name, points_on_plane[0], points_on_plane[1], points_on_plane[2]);
+  auto & csg_plane = csg_obj->addSurface(plane_ptr);
+
+  // This should error as point used to evaluate halfspace lies on the plane
+  csg_plane.getHalfspaceFromPoint(points_on_plane[0]);
+
+  return csg_obj;
+}

--- a/test/tests/csg/csg_only_equality_halfspace_error.i
+++ b/test/tests/csg/csg_only_equality_halfspace_error.i
@@ -1,0 +1,6 @@
+[Mesh]
+  [csg_inf_square]
+    type = TestCSGAmbiguousHalfspaceError
+    side_length = 5
+  []
+[]

--- a/test/tests/csg/tests
+++ b/test/tests/csg/tests
@@ -149,6 +149,15 @@
       expect_err = 'Provided points to define a CSGPlane are collinear'
       mesh_mode = REPLICATED
     []
+    [equality_halfspace]
+      max_threads = 1
+      type = 'RunException'
+      input = 'csg_only_equality_halfspace_error.i'
+      detail = ' trying to define a halfspace of a surface based on a point that lies on the surface'
+      cli_args = '--csg-only'
+      expect_err = 'ambiguously defined halfspace'
+      mesh_mode = REPLICATED
+    []
     [distributed_mesh]
       max_threads = 1
       type = RunException


### PR DESCRIPTION
<!--
If this PR is associated with an issue be sure to reference it
by including "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).

If this PR implements an enhancement that does not have an existing issue, please add the following:
-->

## Reason
<!--Why do you need this feature or what is the enhancement?-->

## Design
<!--A concise description (design) of the enhancement.-->

## Impact
<!--Will the enhancement change existing APIs or add something new?-->


<!--
If this PR implements a bug fix, please create an issue for the bug and reference the issue.
-->
